### PR TITLE
Simple Certificate - Language fix

### DIFF
--- a/lang/en/simplecertificate.php
+++ b/lang/en/simplecertificate.php
@@ -28,7 +28,7 @@ $string['opendownload'] = 'Click the button below to save your certificate to yo
 $string['openemail'] = 'Click the button below and your certificate will be sent to you as an email attachment.';
 $string['openwindow'] = 'Click the button below to open your certificate in a new browser window.';
 $string['hours'] = 'hours';
-$string['keywords'] = 'cetificate, course, pdf, moodle';
+$string['keywords'] = 'certificate, course, pdf, moodle';
 $string['pluginadministration'] = 'Certificate administration';
 $string['deletissuedcertificates'] = 'Delete issued certificates';
 $string['nocertificatesissued'] = 'There are no certificates that have been issued';
@@ -58,7 +58,7 @@ $string['secondpagetext'] = 'Certificate Back Text';
 $string['secondpagex'] = 'Certificate Back Text Horizontal Position';
 $string['secondpagey'] = 'Certificate Back Text Vertical Position';
 $string['secondtextposition'] = 'Certificate Back Text Position';
-$string['secondtextposition_help'] = 'These are the XY coordinates (in millimeters) of the certificate back page text';
+$string['secondtextposition_help'] = 'These are the XY coordinates (in millimetres) of the certificate back page text';
 
 //QR Code
 $string['printqrcode'] = 'Print Certificate QR Code';
@@ -66,8 +66,8 @@ $string['printqrcode_help'] = 'Print (or not) certificate QR Code';
 $string['codex'] = 'Certificate QR Code Horizontal Position';
 $string['codey'] = 'Certificate QR Code Vertical Position';
 $string['qrcodeposition'] = 'Certificate QR Code Position';
-$string['qrcodeposition_help'] = 'These are the XY coordinates (in millimeters) of the certificate QR Code';
-$string['defaultcodex'] = 'Default Hotizontal QR code Position';
+$string['qrcodeposition_help'] = 'These are the XY coordinates (in millimetres) of the certificate QR Code';
+$string['defaultcodex'] = 'Default Horizontal QR code Position';
 $string['defaultcodey'] = 'Default Vertical QR code Position';
 
 ////Date options
@@ -93,7 +93,7 @@ $string['delivery'] = 'Delivery';
 $string['openbrowser'] = 'Open in new window';
 $string['download'] = 'Force download';
 $string['emailcertificate'] = 'Email';
-$string['nodelivering'] = 'No delivering, user will recive this certificate using others ways';
+$string['nodelivering'] = 'No delivering, user will receive this certificate using others ways';
 
 
 
@@ -102,41 +102,41 @@ $string['nodelivering'] = 'No delivering, user will recive this certificate usin
 $string['certificatename_help'] = 'Certificate Name';
 $string['certificatetext_help'] = 'This is the text that will be used in the certificate back, some special words will be replaced with variables such as course name, student\'s name, grade ...
 These are:
-
-{USERNAME} -> Full user name
-{COURSENAME} -> Full course name (or a Defined alternate course name)
-{GRADE} -> Formated Grade
-{DATE} -> Formated Date
-{OUTCOME} -> Outcomes
-{HOURS} -> Defined hours in course
-{TEACHERS} -> Teachers List
-{IDNUMBER} -> User id number
-{FIRSTNAME} -> User first name        
-{LASTNAME} -> User last name        
-{EMAIL} -> User e-mail        
-{ICQ} -> User ICQ        
-{SKYPE} -> User Skype        
-{YAHOO} -> User yahoo messenger        
-{AIM} -> User AIM        
-{MSN} -> User MSN        
-{PHONE1} -> User 1° Phone Number        
-{PHONE2} -> User 2° Phone Number        
-{INSTITUTION} -> User institution        
-{DEPARTMENT} -> User department        
-{ADDRESS} -> User address
-{CITY} -> User city
-{COUNTRY} -> User country
-{URL} -> User Home-page
-{CERTIFICATECODE} -> Unique certificate code text
-{PROFILE_xxxx} -> User custom profile fields
-
-In order to use custom profiles fields you must use "PORFILE_" prefix, for example: you has created a custom profile with shortname of "birthday," so the text mark used on certificate must be {PROFILE_BIRTHDAY} 
-The text can use basic html, basic fonts, tables,  but avoid any position definition';
+<ul>
+<li>{USERNAME} -> Full user name</li>
+<li>{COURSENAME} -> Full course name (or a defined alternate course name)</li>
+<li>{GRADE} -> Formatted Grade</li>
+<li>{DATE} -> Formatted Date</li>
+<li>{OUTCOME} -> Outcomes</li>
+<li>{HOURS} -> Defined hours in course</li>
+<li>{TEACHERS} -> Teachers List</li>
+<li>{IDNUMBER} -> User id number</li>
+<li>{FIRSTNAME} -> User first name</li>
+<li>{LASTNAME} -> User last name</li>
+<li>{EMAIL} -> User e-mail</li>
+<li>{ICQ} -> User ICQ</li>
+<li>{SKYPE} -> User Skype</li>
+<li>{YAHOO} -> User yahoo messenger</li>
+<li>{AIM} -> User AIM</li>
+<li>{MSN} -> User MSN</li>
+<li>{PHONE1} -> User 1° Phone Number</li>
+<li>{PHONE2} -> User 2° Phone Number</li>
+<li>{INSTITUTION} -> User institution</li>
+<li>{DEPARTMENT} -> User department</li>
+<li>{ADDRESS} -> User address</li>
+<li>{CITY} -> User city</li>
+<li>{COUNTRY} -> User country</li>
+<li>{URL} -> User Home-page</li>
+<li>{CERTIFICATECODE} -> Unique certificate code text</li>
+<li>{PROFILE_xxxx} -> User custom profile fields</li>
+</ul>
+In order to use custom profiles fields you must use "PORFILE_" prefix, for example: you has created a custom profile with shortname of "birthday," so the text mark used on certificate must be {PROFILE_BIRTHDAY}.
+The text can use basic html, basic fonts, tables,  but avoid any position definition.';
 
 $string['textposition'] = 'Certificate Text Position';
-$string['textposition_help'] = 'These are the XY coordinates (in millimeters) of the certificate text';
+$string['textposition_help'] = 'These are the XY coordinates (in millimetres) of the certificate text';
 $string['size'] = 'Certificate Size';
-$string['size_help'] = 'These are the Width and Height size (in millimeters) of the certificate, Default size is A4 Landscape';
+$string['size_help'] = 'These are the Width and Height size (in millimetres) of the certificate, Default size is A4 Landscape';
 $string['coursehours_help'] = 'Hours in course';
 $string['coursename_help'] = 'Alternative Course Name';
 $string['certificateimage_help'] = 'This is the picture that will be used in the certificate';
@@ -146,20 +146,23 @@ $string['printdate_help'] = 'This is the date that will be printed, if a print d
 $string['datefmt_help'] = 'Enter a valid PHP date format pattern (http://www.php.net/manual/en/function.strftime.php). Or, leave it empty to use the format of the user\'s chosen language.';
 $string['printgrade_help'] = 'You can choose any available course grade items from the gradebook to print the user\'s grade received for that item on the certificate.  The grade items are listed in the order in which they appear in the gradebook. Choose the format of the grade below.';
 $string['gradefmt_help'] = 'There are three available formats if you choose to print a grade on the certificate:
-
-Percentage Grade: Prints the grade as a percentage.
-Points Grade: Prints the point value of the grade.
-Letter Grade: Prints the percentage grade as a letter.';
+<ul>
+<li>Percentage Grade: Prints the grade as a percentage.</li>
+<li>Points Grade: Prints the point value of the grade.</li>
+<li>Letter Grade: Prints the percentage grade as a letter.</li>
+</ul>';
 
 $string['coursetimereq_help'] = 'Enter here the minimum amount of time, in minutes, that a student must be logged into the course before they will be able to receive the certificate.';
 $string['emailteachers_help'] = 'If enabled, then teachers are alerted with an email whenever students receive a certificate.';
 $string['emailothers_help'] = 'Enter the email addresses here, separated by a comma, of those who should be alerted with an email whenever students receive a certificate.';
 $string['emailfrom_help'] = 'Alternate email form name';
 $string['delivery_help'] = 'Choose here how you would like your students to get their certificate.
-Open in Browser: Opens the certificate in a new browser window.
-Force Download: Opens the browser file download window.
-Email Certificate: Choosing this option sends the certificate to the student as an email attachment.
-After a user receives their certificate, if they click on the certificate link from the course homepage, they will see the date they received their certificate and will be able to review their received certificate.';
+<ul>
+<li>Open in Browser: Opens the certificate in a new browser window.</li>
+<li>Force Download: Opens the browser file download window.</li>
+<li>Email Certificate: Choosing this option sends the certificate to the student as an email attachment.</li>
+<li>After a user receives their certificate, if they click on the certificate link from the course homepage, they will see the date they received their certificate and will be able to review their received certificate.</li>
+</ul>';
 
 ////Form Sections
 $string['issueoptions'] = 'Issue Options';
@@ -168,10 +171,10 @@ $string['designoptions'] = 'Design Options';
 //Emails text
 $string['emailstudentsubject'] = 'Your certificate for {$a->course}';
 $string['emailstudenttext'] = '
-Hello {$a->username}, 
-		
+Hello {$a->username},
+
 		Attached is your certificate for {$a->course}.
-		
+
 
 THIS IS AN AUTOMATED MESSAGE - PLEASE DO NOT REPLY';
 
@@ -196,7 +199,7 @@ You can review it here:
 //Admin settings page
 $string['defaultwidth'] = 'Default Width';
 $string['defaultheight'] = 'Default Height';
-$string['defaultcertificatetextx'] = 'Default Hotizontal Text Position';
+$string['defaultcertificatetextx'] = 'Default Horizontal Text Position';
 $string['defaultcertificatetexty'] = 'Default Vertical Text Position';
 
 
@@ -212,7 +215,7 @@ $string['certificateverification'] = 'Certificate Verification';
 
 //Settings
 $string['certlifetime'] = 'Keep issued certificates for: (in Months)';
-$string['certlifetime_help'] = 'This specifies the length of time you want to keep issued certificates. Issed certificates that are older than this age are automatically deleted.';
+$string['certlifetime_help'] = 'This specifies the length of time you want to keep issued certificates. Issued certificates that are older than this age are automatically deleted.';
 $string['neverdeleteoption'] = 'Never delete';
 
 $string['variablesoptions'] = 'Others Options';
@@ -220,7 +223,7 @@ $string['getcertificate'] = 'Get Certificate';
 $string['verifycertificate'] = 'Verify Certificate';
 
 $string['qrcodefirstpage'] = 'Print QR Code in the first page';
-$string['qrcodefirstpage_help'] = 'Print QR Code in the first page'; 
+$string['qrcodefirstpage_help'] = 'Print QR Code in the first page';
 
 
 //Tabs String
@@ -235,7 +238,7 @@ $string['onepdf'] = 'Download certificates in a one pdf file';
 $string['multipdf'] = 'Download certificates in a zip file';
 $string['sendtoemail'] = 'Send to user\'s email';
 $string['showusers'] = 'Show';
-$string['completedusers'] = 'Users that met the course objectives'; 
+$string['completedusers'] = 'Users that met the course objectives';
 $string['allusers'] = 'All users';
 $string['bulkaction'] = 'Choose a Bulk Operation';
 $string['bulkbuttonlabel'] = 'Send';

--- a/locallib.php
+++ b/locallib.php
@@ -17,7 +17,7 @@
 
 /**
  * Simple Certificate module core interaction API
- * 
+ *
  * @package mod
  * @subpackage simplecertificate
  * @copyright Carlos Alexandre Fonseca <carlos.alexandre@outlook.com>
@@ -34,77 +34,77 @@ require_once ($CFG->libdir . '/pdflib.php');
 require_once ($CFG->dirroot . '/user/profile/lib.php');
 
 class simplecertificate {
-    
+
     const CERTIFICATE_IMAGE_FILE_AREA = 'image';
     const CERTIFICATE_ISSUES_FILE_AREA = 'private'; // issues';
     const CERTIFICATE_COMPONENT_NAME = 'mod_simplecertificate';
     const OUTPUT_OPEN_IN_BROWSER = 0;
     const OUTPUT_FORCE_DOWNLOAD = 1;
     const OUTPUT_SEND_EMAIL = 2;
-    
+
     // Date Options Const
     const CERT_ISSUE_DATE = -1;
     const COURSE_COMPLETATION_DATE = -2;
-    
+
     // Grade Option Const
     const NO_GRADE = 0;
     const COURSE_GRADE = -1;
-    
+
     // View const
     const DEFAULT_VIEW = 0;
     const ISSUED_CERTIFCADES_VIEW = 1;
     const BULK_ISSUE_CERTIFCADES_VIEW = 2;
-    
+
     // pagination
     const SIMPLECERT_MAX_PER_PAGE = 200;
-    
+
     /**
      * @var stdClass the assignment record that contains the global settings for this simplecertificate instance
      */
     private $instance;
-    
+
     /**
      * @var context the context of the course module for this simplecertificate instance
      * (or just the course if we are creating a new one)
      */
     private $context;
-    
+
     /**
      * @var stdClass the course this simplecertificate instance belongs to
      */
     private $course;
-    
+
     /**
      * @var stdClass the admin config for all simplecertificate instances
      */
     private $adminconfig;
-    
+
     /**
      * @var assign_renderer the custom renderer for this module
      */
     private $output;
-    
+
     /**
      * @var stdClass the course module for this simplecertificate instance
      */
     private $coursemodule;
-    
+
     /**
      * @var array cache for things like the coursemodule name or the scale menu -
      * only lives for a single request.
      */
     private $cache;
-    
+
     /**
-     * 
+     *
      * @var stdClass the current issued certificate
      */
     private $issuecert;
-    
-    
+
+
     /**
      * Constructor for the base simplecertificate class.
-     * 
+     *
      * @param mixed $coursemodulecontext context|null the course module context
      *        (or the course context if the coursemodule has not been
      *        created yet).
@@ -114,41 +114,41 @@ class simplecertificate {
      *        otherwise this class will load one from the context as required.
      */
     public function __construct($coursemodulecontext, $coursemodule = null, $course = null) {
-        $this->context = $coursemodulecontext; 
-        $this->coursemodule = $coursemodule; 
+        $this->context = $coursemodulecontext;
+        $this->coursemodule = $coursemodule;
         $this->course = $course;
-         
-        //Temporary cache only lives for a single request - used to reduce db lookups. 
-        $this->cache = array(); 
+
+        //Temporary cache only lives for a single request - used to reduce db lookups.
+        $this->cache = array();
     }
-    
-    
+
+
     /**
      * Add this instance to the database.
-     * 
+     *
      * @param stdClass $formdata The data submitted from the form
      * @param mod_simplecertificate_mod_form $mform the form object to get files
      * @return mixed false if an error occurs or the int id of the new instance
      */
     public function add_instance(stdClass $formdata) {
         global $DB;
-        
+
         //Add the database record.
         $update = $this->populate_simplecertificate_instance($formdata);
         $update->timecreated = time();
         $update->timemodified = $update->timecreated;
-        
+
         $returnid = $DB->insert_record('simplecertificate', $update, true);
-               
+
         $this->course = $DB->get_record('course', array('id' => $formdata->course), '*', MUST_EXIST);
-        
+
         if(!$this->instance = $DB->get_record('simplecertificate', array('id'=>$returnid), '*', MUST_EXIST)) {
             print_erro('certificatenot','simplecertificate');
         }
-        
+
         return $returnid;
     }
-    
+
     /**
      * Update this instance in the database.
      *
@@ -157,26 +157,26 @@ class simplecertificate {
      */
     public function update_instance(stdClass $formdata) {
         global $DB;
-    
+
         $update = $this->populate_simplecertificate_instance($formdata);
         $update->timemodified = time();
 
         $result = $DB->update_record('simplecertificate', $update);
-        
+
         if (!$DB->execute('UPDATE {simplecertificate_issues} SET haschange = 1 WHERE timedeleted is NULL AND certificateid = :certid',
                      array('certid'=>$this->get_instance()->id))) {
-            print_error('cannotupdatemod', '', '', self::CERTIFICATE_COMPONENT_NAME, 'Error update simplecertificate, markig issues 
+            print_error('cannotupdatemod', '', '', self::CERTIFICATE_COMPONENT_NAME, 'Error update simplecertificate, markig issues
                      with has change');
         }
-        
+
         if(!$this->instance = $DB->get_record('simplecertificate', array('id'=>$update->id), '*', MUST_EXIST)) {
             print_erro('certificatenot','simplecertificate');
         }
-    
+
         return $result;
     }
-    
-    
+
+
     /**
      * Delete this instance from the database.
      *
@@ -185,29 +185,29 @@ class simplecertificate {
     public function delete_instance() {
         global $DB;
         $result = true;
-    
+
         // Delete files associated with this certificate.
         $fs = get_file_storage();
         if (!$fs->delete_area_files($this->context->id)) {
             $result = false;
         }
-        
+
         //Update issued certificate
-        if (!$DB->execute('UPDATE {simplecertificate_issues} SET timedeleted = :timedeleted WHERE timedeleted is NULL AND 
+        if (!$DB->execute('UPDATE {simplecertificate_issues} SET timedeleted = :timedeleted WHERE timedeleted is NULL AND
                      certificateid = :certid', array('timedeleted'=>time(), 'certid'=>$this->get_instance()->id))) {
-            print_error('cannotdeletedir', '', '', self::CERTIFICATE_COMPONENT_NAME, 'Error delete simplecertificate, markig issues 
+            print_error('cannotdeletedir', '', '', self::CERTIFICATE_COMPONENT_NAME, 'Error delete simplecertificate, markig issues
                      with timedelete');
         }
-     
+
         // Delete the instance.
         $DB->delete_records('simplecertificate', array('id'=>$this->get_instance()->id));
-    
+
         return $result;
     }
 
     /**
      * Get the settings for the current instance of this certificate
-     * 
+     *
      * @return stdClass The settings
      */
     public function get_instance() {
@@ -227,7 +227,7 @@ class simplecertificate {
 
     /**
      * Get context module.
-     * 
+     *
      * @return context
      */
     public function get_context() {
@@ -236,28 +236,28 @@ class simplecertificate {
 
     /**
      * Get the current course.
-     * 
+     *
      * @return mixed stdClass|null The course
      */
     public function get_course() {
         global $DB;
-        
+
         if ($this->course) {
             return $this->course;
         }
-        
+
         if (!$this->context) {
             return null;
         }
         $params = array('id' => $this->get_course_context()->instanceid);
         $this->course = $DB->get_record('course', $params, '*', MUST_EXIST);
-        
+
         return $this->course;
     }
 
     /**
      * Get the context of the current course.
-     * 
+     *
      * @return mixed context|null The course context
      */
     public function get_course_context() {
@@ -270,7 +270,7 @@ class simplecertificate {
             return context_course::instance($this->course->id);
         }
     }
-    
+
     /**
      * Get the current course module.
      *
@@ -280,11 +280,11 @@ class simplecertificate {
         if ($this->coursemodule) {
             return $this->coursemodule;
         }
-        
+
         if (!$this->context) {
             return null;
         }
-    
+
         if ($this->context->contextlevel == CONTEXT_MODULE) {
             $this->coursemodule = get_coursemodule_from_id('simplecertificate', $this->context->instanceid, 0, false, MUST_EXIST);
             return $this->coursemodule;
@@ -294,7 +294,7 @@ class simplecertificate {
 
     /**
      * Set the submitted form data.
-     * 
+     *
      * @param stdClass $data The form data (instance)
      */
     public function set_instance(stdClass $data) {
@@ -303,7 +303,7 @@ class simplecertificate {
 
     /**
      * Set the context.
-     * 
+     *
      * @param context $context The new context
      */
     public function set_context(context $context) {
@@ -312,16 +312,16 @@ class simplecertificate {
 
     /**
      * Set the course data.
-     * 
+     *
      * @param stdClass $course The course data
      */
     public function set_course(stdClass $course) {
         $this->course = $course;
     }
-    
+
     /**
-     * 
-     * @param stdClass $formdata  The data submitted from the form 
+     *
+     * @param stdClass $formdata  The data submitted from the form
      * @param mod_simplecertificate_mod_form $mform The form object to get files
      * @return stdClass The simplecertificate instance object
      */
@@ -337,7 +337,7 @@ class simplecertificate {
             }
             unset($formdata->certificatetext);
         }
-        
+
         if (isset($formdata->secondpagetext['text'])) {
             $update->secondpagetext = $formdata->secondpagetext['text'];
             if (!isset($formdata->secondpagetextformat)){
@@ -345,9 +345,9 @@ class simplecertificate {
             }
             unset($formdata->secondpagetext);
         }
-        
+
         if (!empty($formdata->images)) {
-            $user_context = context_user::instance($USER->id); 
+            $user_context = context_user::instance($USER->id);
             $fs = get_file_storage();
             if (!empty($formdata->images[0])) {
                 $fileinfo = self::get_certificate_image_fileinfo($this->context->id);
@@ -371,28 +371,28 @@ class simplecertificate {
             }
             unset($formdata->images);
         }
-        
+
         foreach ($formdata as $name => $value) {
             $update->{$name} = $value;
         }
-        
+
         if (isset($formdata->instance)){
             $update->id = $formdata->instance;
             unset($update->instance);
         }
-        
+
         if (empty($update->coursename)) {
             $update->coursename = $this->get_course()->fullname;
         }
-        
+
         return $update;
     }
-    
-   
+
+
 
     /**
      * Get the first page background image fileinfo
-     * 
+     *
      * @param mixed $context The module context object or id
      * @return the first page background image fileinfo
      */
@@ -412,10 +412,10 @@ class simplecertificate {
         );
         return $fileinfo;
     }
-    
+
     /**
      * Get the second page background image fileinfo
-     * 
+     *
      * @param mixed $context The module context object or id
      * @return the second page background image fileinfo
      */
@@ -425,7 +425,7 @@ class simplecertificate {
         } else {
             $contextid = $context;
         }
-    
+
         $fileinfo = array(
                 'contextid' => $contextid, // ID of context
                 'component' => self::CERTIFICATE_COMPONENT_NAME, // usually = table name
@@ -443,45 +443,45 @@ class simplecertificate {
      * @return the the issued certificatfileinfo
      */
     public static function get_certificate_issue_fileinfo($issuecert) {
-		global $DB;
-		
-		//Load Issue certificate
-		if (!is_object($issuecert)) {
-		    if (!$issuecert=$DB->get_record('simplecertificate_issues', array('id'=>$issuecert))) {
-		        print_error('issuedcertificatenotfound','simplecertificate');
-		    }
-		}
-		
-		if (empty($issuecert->coursename)) {
-			//Try to cacth course name
-			if ($cert=$DB->get_record('simplecertificate', array('id'=>$issuecert->certificateid))) {
-				$course = get_course($cert->course);
-			}
-			if (empty($course)) {
-				error_log(get_string('coursenotfound','simplecertificate'));
-				print_error('coursenotfound','simplecertificate');
-			}
-			$issuecert->coursename = $course->fullname;
-			$DB->update_record('simplecertificate_issues', $issuecert);
-		}
-		
-		try {
-		    $context = context_user::instance($issuecert->userid);
-		} catch (Exception $e) {
-		    erro_log(get_string('usercontextnotfound','simplecertificate'));
-		    print_error('usercontextnotfound','simplecertificate');
-		    die;
-		}
-    		
-		if ($user=$DB->get_record("user", array('id'=>$issuecert->userid))) {
-			$filename = str_replace(' ', '_', clean_filename($issuecert->certificatename .' '. fullname($user) .' '. $issuecert->id
-			          . '.pdf'));
-		} else {
-			error_log(get_string('usernotfound','simplecertificate'));
-			print_error('usernotfound','simplecertificate');
-			die;
-		}
-        
+        global $DB;
+
+        //Load Issue certificate
+        if (!is_object($issuecert)) {
+            if (!$issuecert=$DB->get_record('simplecertificate_issues', array('id'=>$issuecert))) {
+                print_error('issuedcertificatenotfound','simplecertificate');
+            }
+        }
+
+        if (empty($issuecert->coursename)) {
+            //Try to cacth course name
+            if ($cert=$DB->get_record('simplecertificate', array('id'=>$issuecert->certificateid))) {
+                $course = get_course($cert->course);
+            }
+            if (empty($course)) {
+                error_log(get_string('coursenotfound','simplecertificate'));
+                print_error('coursenotfound','simplecertificate');
+            }
+            $issuecert->coursename = $course->fullname;
+            $DB->update_record('simplecertificate_issues', $issuecert);
+        }
+
+        try {
+            $context = context_user::instance($issuecert->userid);
+        } catch (Exception $e) {
+            erro_log(get_string('usercontextnotfound','simplecertificate'));
+            print_error('usercontextnotfound','simplecertificate');
+            die;
+        }
+
+        if ($user=$DB->get_record("user", array('id'=>$issuecert->userid))) {
+            $filename = str_replace(' ', '_', clean_filename($issuecert->certificatename .' '. fullname($user) .' '. $issuecert->id
+                      . '.pdf'));
+        } else {
+            error_log(get_string('usernotfound','simplecertificate'));
+            print_error('usernotfound','simplecertificate');
+            die;
+        }
+
         $fileinfo = array(
                 'contextid' => $context->id, // ID of context
                 'component' => 'user',
@@ -489,8 +489,8 @@ class simplecertificate {
                 'itemid' => 0, //$issuecert->id, // usually = ID of row in table
                 'filepath' => '/certificates/'.$issuecert->coursename.'/', // any path beginning and ending in /
                 'mimetype' => 'application/pdf', // any filename
-                'userid' => $issuecert->userid, 
-        		'filename' => $filename
+                'userid' => $issuecert->userid,
+                'filename' => $filename
         );
 
         return $fileinfo;
@@ -499,24 +499,24 @@ class simplecertificate {
     /**
      * Inserts preliminary user data when a certificate is viewed.
      * Prevents form from issuing a certificate upon browser refresh.
-     * 
+     *
      * @param stdClass $user
      * @return stdClass the newly created certificate issue
      */
     public function get_issue($user = null) {
         global $DB, $USER;
-        
+
         if (empty($user)) {
             $user = $USER;
         }
-        
+
         if (!empty($this->issuecert) && !empty($issuecert->haschange) && $this->issuecert->userid == $user->id) {
             return $this->issuecert;
         }
-        
+
         //Check if certificate has already issued
-        if (!$issuecert = $DB->get_record('simplecertificate_issues', array('userid' => $user->id, 
-                'certificateid' => $this->get_instance()->id, 
+        if (!$issuecert = $DB->get_record('simplecertificate_issues', array('userid' => $user->id,
+                'certificateid' => $this->get_instance()->id,
                         'timedeleted' => null))) {
             // Create new certificate issue record
             $issuecert = new stdClass();
@@ -529,17 +529,17 @@ class simplecertificate {
             $issuecert->certificatename = format_string($formated_coursename . '-' . $formated_certificatename, true);
             $issuecert->timecreated = time();
             $issuecert->code = $this->get_issue_uuid();
-            
+
             if (has_capability('mod/simplecertificate:manage', $this->context, $user)) {
                 $issuecert->id = 0;
             } else {
                 $issuecert->id = $DB->insert_record('simplecertificate_issues', $issuecert);
-                
+
                 // Email to the teachers and anyone else
-            	if (!empty($this->get_instance()->emailteachers)) {
+                if (!empty($this->get_instance()->emailteachers)) {
                     $this->send_alert_email_teachers();
-            	}
-            	
+                }
+
                 if (!empty($this->get_instance()->emailothers)) {
                     $this->send_alert_email_others();
                 }
@@ -558,36 +558,36 @@ class simplecertificate {
 
     /**
      * Returns a list of previously issued certificates--used for reissue.
-     * 
+     *
      * @param int $certificateid
      * @return stdClass the attempts else false if none found
      */
     public function get_attempts() {
         global $DB, $USER;
-        
+
         $sql = "SELECT *
                 FROM {simplecertificate_issues} i
                 WHERE certificateid = :certificateid
                 AND userid = :userid AND timedeleted IS NULL";
-        
+
         if ($issues = $DB->get_records_sql($sql, array('certificateid' => $this->get_instance()->id, 'userid' => $USER->id ))) {
             return $issues;
         }
-        
+
         return false;
     }
 
     /**
      * Prints a table of previously issued certificates--used for reissue.
-     * 
+     *
      * @param stdClass $attempts
      * @return string the attempt table
      */
     public function print_attempts($attempts) {
         global $OUTPUT, $DB;
-        
+
         echo $OUTPUT->heading(get_string('summaryofattempts', 'simplecertificate'));
-        
+
         // Prepare table header
         $table = new html_table();
         $table->class = 'generaltable';
@@ -595,7 +595,7 @@ class simplecertificate {
         $table->align = array('left');
         $table->attributes = array("style" => "width:20%; margin:auto");
         $gradecolumn = $this->get_instance()->certgrade;
-        
+
         if ($gradecolumn) {
             $table->head[] = get_string('grade');
             $table->align[] = 'center';
@@ -604,40 +604,40 @@ class simplecertificate {
         // One row for each attempt
         foreach ( $attempts as $attempt ) {
             $row = array();
-            
+
             // prepare strings for time taken and date completed
             $datecompleted = userdate($attempt->timecreated);
             $row[] = $datecompleted;
-            
+
             if ($gradecolumn) {
                 $attemptgrade = $this->get_grade();
                 $row[] = $attemptgrade;
             }
-            
+
             $table->data[$attempt->id] = $row;
         }
-        
+
         echo html_writer::table($table);
     }
 
     /**
      * Returns the grade to display for the certificate.
-     * 
+     *
      * @param int $userid
      * @return string the grade result
      */
     protected function get_grade($userid = null) {
         global $USER, $DB;
-        
+
         if (empty($userid)) {
             $userid = $USER->id;
         }
-        
+
         //If certgrade = 0 return nothing
         if (empty($this->get_instance()->certgrade)) { //No grade
             return '';
         }
-        
+
         switch ($this->get_instance()->certgrade) {
             case self::COURSE_GRADE: //Course grade
                 if ($course_item = grade_item::fetch_course_item($this->get_course()->id)) {
@@ -645,15 +645,15 @@ class simplecertificate {
                     $course_item->gradetype = GRADE_TYPE_VALUE;
                     $coursegrade = new stdClass();
                     // String used
-                    $coursegrade->points = grade_format_gradevalue($grade->finalgrade, $course_item, true, GRADE_DISPLAY_TYPE_REAL, 
+                    $coursegrade->points = grade_format_gradevalue($grade->finalgrade, $course_item, true, GRADE_DISPLAY_TYPE_REAL,
                                          $decimals = 2);
-                    $coursegrade->percentage = grade_format_gradevalue($grade->finalgrade, $course_item, true, 
+                    $coursegrade->percentage = grade_format_gradevalue($grade->finalgrade, $course_item, true,
                                              GRADE_DISPLAY_TYPE_PERCENTAGE, $decimals = 2);
-                    $coursegrade->letter = grade_format_gradevalue($grade->finalgrade, $course_item, true, 
+                    $coursegrade->letter = grade_format_gradevalue($grade->finalgrade, $course_item, true,
                                          GRADE_DISPLAY_TYPE_LETTER, $decimals = 0);
                 }
             break;
-            
+
             default: //Module grade
                 //Get grade from a specific module, stored at certgrade
                 if ($modinfo = $this->get_mod_grade($this->get_instance()->certgrade, $userid)) {
@@ -665,10 +665,10 @@ class simplecertificate {
                     break;
                 }
         }
-        
+
         return $this->get_formated_grade($coursegrade);
     }
-    
+
     private function get_formated_grade (stdClass $coursegrade) {
         if (empty($coursegrade)) {
             return '';
@@ -678,11 +678,11 @@ class simplecertificate {
                 case 1 :
                     return $coursegrade->percentage;
                     break;
-                
+
                 case 3 :
                     return $coursegrade->letter;
                     break;
-                    
+
                 default:
                     return $coursegrade->points;
                     break;
@@ -691,17 +691,17 @@ class simplecertificate {
 
     /**
      * Prepare to print an activity grade.
-     * 
+     *
      * @param int $moduleid
      * @param int $userid
      * @return stdClass bool the mod object if it exists, false otherwise
      */
     protected function get_mod_grade($moduleid, $userid) {
         global $DB;
-        
+
         $cm = $DB->get_record('course_modules', array('id' => $moduleid));
         $module = $DB->get_record('modules', array('id' => $cm->module));
-        
+
         if ($grade_item = grade_get_grades($this->get_course()->id, 'mod', $module->name, $cm->instance, $userid)) {
             $item = new grade_item();
             $itemproperties = reset($grade_item->items);
@@ -713,11 +713,11 @@ class simplecertificate {
             $grade = $item->grades[$userid]->grade;
             $item->gradetype = GRADE_TYPE_VALUE;
             $item->courseid = $this->get_course()->id;
-            
+
             $modinfo->points = grade_format_gradevalue($grade, $item, true, GRADE_DISPLAY_TYPE_REAL, $decimals = 2);
             $modinfo->percentage = grade_format_gradevalue($grade, $item, true, GRADE_DISPLAY_TYPE_PERCENTAGE, $decimals = 2);
             $modinfo->letter = grade_format_gradevalue($grade, $item, true, GRADE_DISPLAY_TYPE_LETTER, $decimals = 0);
-            
+
             if ($grade) {
                 $modinfo->dategraded = $item->grades[$userid]->dategraded;
             } else {
@@ -725,7 +725,7 @@ class simplecertificate {
             }
             return $modinfo;
         }
-        
+
         return false;
     }
 
@@ -733,7 +733,7 @@ class simplecertificate {
      * Generate a version 1 UUID (time based)
      * you can verify the generated code in:
      * http://www.famkruithof.net/uuid/uuidgen?typeReq=-1
-     * 
+     *
      * @return string UUID_v1
      */
     protected function get_issue_uuid() {
@@ -746,13 +746,13 @@ class simplecertificate {
     /**
      * Returns a list of teachers by group
      * for sending email alerts to teachers
-     * 
+     *
      * @return array the teacher array
      */
     protected function get_teachers() {
         global $CFG, $USER, $DB;
         $teachers = array();
-        
+
         if (!empty($CFG->coursecontact)) {
             $coursecontactroles = explode(',', $CFG->coursecontact);
         } else {
@@ -765,7 +765,7 @@ class simplecertificate {
                 foreach ( $users as $teacher ) {
                     if ($teacher->id == $USER->id) {
                         continue; // do not send self
-					}
+                    }
                     $manager = new stdClass();
                     $manager->user = $teacher;
                     $manager->username = fullname($teacher);
@@ -811,19 +811,19 @@ class simplecertificate {
      */
     protected function send_alert_emails($emails) {
         global $USER, $CFG, $DB;
-        
+
         if (!empty($emails)) {
-            
-            $url = new moodle_url($CFG->wwwroot . '/mod/simplecertificate/view.php', array('id' => $this->coursemodule->id, 
+
+            $url = new moodle_url($CFG->wwwroot . '/mod/simplecertificate/view.php', array('id' => $this->coursemodule->id,
                     'tab' => self::ISSUED_CERTIFCADES_VIEW));
-            
+
             foreach ( $emails as $email ) {
                 $email = trim($email);
                 if (validate_email($email)) {
                     $destination = new stdClass();
                     $destination->email = $email;
                     $destination->id = rand(-10, -1);
-                    
+
                     $info = new stdClass();
                     $info->student = fullname($USER);
                     $info->course = format_string($this->get_instance()->coursename, true);
@@ -831,15 +831,15 @@ class simplecertificate {
                     $info->url = $url->out();
                     $from = $info->student;
                     $postsubject = get_string('awardedsubject', 'simplecertificate', $info);
-                    
+
                     //Getting email body plain text
                     $posttext = get_string('emailteachermail', 'simplecertificate', $info) . "\n";
-                    
+
                     //Getting email body html
                     $posthtml = '<font face="sans-serif">';
                     $posthtml .= '<p>' . get_string('emailteachermailhtml', 'simplecertificate', $info) . '</p>';
                     $posthtml .= '</font>';
-                    
+
                     @email_to_user($destination, $from, $postsubject, $posttext, $posthtml); // If it fails, oh well, too bad.
                 }
             }
@@ -848,28 +848,33 @@ class simplecertificate {
 
     /**
      * Create PDF object using parameters
-     * 
+     *
      * @return PDF
      */
     protected function create_pdf_object() {
-        
+
         //Default orientation is Landescape
         $orientation = 'L';
-        
+
         if ($this->get_instance()->height > $this->get_instance()->width) {
             $orientation = 'P';
-        } 
-        
+        }
+
+        // Remove commas to avoid a bug in TCPDF where a string containing a commas will result in two strings.
+        $keywords = get_string('keywords', 'simplecertificate') . ',' . format_string($this->coursename, true);
+        $keywords = str_replace(",", " ", $keywords);  // Replace commas with spaces.
+        $keywords = str_replace("  ", " ", $keywords); // Replace two spaces with one.
+
         $pdf = new pdf($orientation, 'mm', array($this->get_instance()->width, $this->get_instance()->height), true, 'UTF-8');
         $pdf->SetTitle($this->get_instance()->name);
         $pdf->SetSubject($this->get_instance()->name . ' - ' . $this->get_instance()->coursename);
-        $pdf->SetKeywords(get_string('keywords', 'simplecertificate') . ',' . $this->get_instance()->coursename);
+        $pdf->SetKeywords($keywords);
         $pdf->setPrintHeader(false);
         $pdf->setPrintFooter(false);
         $pdf->SetAutoPageBreak(false, 0);
         $pdf->setFontSubsetting(true);
         $pdf->SetMargins(0, 0, 0, true);
-        
+
         return $pdf;
     }
 
@@ -878,31 +883,31 @@ class simplecertificate {
      *
      * @param stdClass $issuecert The issue certifcate obeject
      * @param PDF $pdf A PDF object, if null will create one
-     * @param bool $isbulk Tell if it is a bulk operation or not 
+     * @param bool $isbulk Tell if it is a bulk operation or not
      * @return mixed PDF object or error
      */
     protected function create_pdf(stdClass $issuecert, $pdf = null, $isbulk = false) {
         global $DB, $CFG;
-        
+
         //Check if certificate file is already exists, if issued has changes, it will recreated
         if (empty($issuecert->haschange) && $this->issue_file_exists($issuecert) && !$isbulk ) {
             return false;
         }
-        
+
         if (empty($pdf)) {
             $pdf = $this->create_pdf_object();
         }
-        
+
         $pdf->AddPage();
-        
+
         //Getting certificare image
         $fs = get_file_storage();
-        
+
         // Get first page image file
         if (!empty($this->get_instance()->certificateimage)) {
             // Prepare file record object
             $fileinfo = self::get_certificate_image_fileinfo($this->context->id);
-            $firstpageimagefile = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], 
+            $firstpageimagefile = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'],
                                 $fileinfo['itemid'], $fileinfo['filepath'], $this->get_instance()->certificateimage);
             // Read contents
             if ($firstpageimagefile) {
@@ -913,25 +918,25 @@ class simplecertificate {
                 print_error(get_string('filenotfound', 'simplecertificate', $this->get_instance()->certificateimage));
             }
         }
-        
+
         //Writing text
         $pdf->SetXY($this->get_instance()->certificatetextx, $this->get_instance()->certificatetexty);
         $pdf->writeHTMLCell(0, 0, '', '', $this->get_certificate_text($issuecert, $this->get_instance()->certificatetext), 0, 0, 0, true, 'C');
-        
+
         //Print QR code in first page (if enable)
         if (!empty($this->get_instance()->qrcodefirstpage) && !empty($this->get_instance()->printqrcode)) {
             $this->print_qrcode($pdf, $issuecert->code);
         }
-        
+
         if (!empty($this->get_instance()->enablesecondpage)) {
             $pdf->AddPage();
             if (!empty($this->get_instance()->secondimage)) {
                 // Prepare file record object
                 $fileinfo = self::get_certificate_secondimage_fileinfo($this->context->id);
                 // Get file
-                $secondimagefile = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], 
+                $secondimagefile = $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'],
                                  $fileinfo['itemid'], $fileinfo['filepath'], $this->get_instance()->secondimage);
-                
+
                 // Read contents
                 if (!empty($secondimagefile)) {
                     $temp_filename = $secondimagefile->copy_content_to_temp(self::CERTIFICATE_COMPONENT_NAME, 'second_image_');
@@ -946,7 +951,7 @@ class simplecertificate {
                 $pdf->writeHTMLCell(0, 0, '', '', $this->get_certificate_text($issuecert, $this->get_instance()->secondpagetext), 0, 0, 0, true, 'C');
             }
         }
-        
+
         if (!empty($this->get_instance()->printqrcode) && empty($this->get_instance()->qrcodefirstpage)) {
             //Add certificade code using QRcode, in a new page (to print in the back)
             if (empty($this->get_instance()->enablesecondpage)) {
@@ -954,7 +959,7 @@ class simplecertificate {
                 $pdf->AddPage();
             }
             $this->print_qrcode($pdf, $issuecert->code);
-        
+
         }
         return $pdf;
     }
@@ -966,15 +971,15 @@ class simplecertificate {
      */
     protected function print_qrcode($pdf, $code) {
         global $CFG;
-        $style = array('border' => 2, 
-                'vpadding' => 'auto', 
-                'hpadding' => 'auto', 
+        $style = array('border' => 2,
+                'vpadding' => 'auto',
+                'hpadding' => 'auto',
                 'fgcolor' => array(0, 0, 0), //black
                 'bgcolor' => array(255, 255, 255), //white
                 'module_width' => 1, // width of a single module in points
                 'module_height' => 1 // height of a single module in points
         );
-        
+
         $codeurl = "$CFG->wwwroot/mod/simplecertificate/verify.php?code=$code";
         $pdf->write2DBarcode($codeurl, 'QRCODE,M', $this->get_instance()->codex, $this->get_instance()->codey, 50, 50, $style, 'N');
         $pdf->SetXY($this->get_instance()->codex, $this->get_instance()->codey + 48);
@@ -983,16 +988,16 @@ class simplecertificate {
 
     /**
      * Save a certificate pdf file
-     * 
+     *
      * @param pdf $pdf The pdf object
      * @param stdClass $issuecert the certificate issue record
      * @return mixed return string with filename if successful, null otherwise
      */
     protected function save_pdf($pdf, stdClass $issuecert) {
         global $DB;
-        
-        
-        
+
+
+
         //Check if file exist
         //if issue certificate has no change, it's must has a file
         if (empty($issuecert->haschange)) {
@@ -1034,47 +1039,47 @@ class simplecertificate {
     /**
      * Sends the student their issued certificate as an email
      * attachment.
-     * 
+     *
      * @param $issuecert The issue certificate object
      */
     protected function send_certificade_email(stdClass $issuecert) {
         global $DB, $CFG;
-        
+
         if (!$user = $DB->get_record('user', array('id' => $issuecert->userid))) {
             print_error('nousersfound', 'moodle');
         }
-        
+
         $info = new stdClass();
         $info->username = format_string(fullname($user), true);
         $info->certificate = format_string($issuecert->certificatename, true);
         $info->course = format_string($issuecert->coursename, true);
-        
+
         $subject = get_string('emailstudentsubject', 'simplecertificate', $info);
         $message = get_string('emailstudenttext', 'simplecertificate', $info) . "\n";
-        
+
         // Make the HTML version more XHTML happy  (&amp;)
         $messagehtml = text_to_html($message);
-        
+
         // Get generated certificate file
         if ($file = $this->get_issue_file($issuecert)) { //put in a tmp dir, for e-mail attachament
-        	$fullfilepath = $this->create_temp_file($file->get_filename());
+            $fullfilepath = $this->create_temp_file($file->get_filename());
             $file->copy_content_to($fullfilepath);
             $relativefilepath = str_replace($CFG->dataroot . DIRECTORY_SEPARATOR, "", $fullfilepath);
-            
+
             if (strpos($relativefilepath, DIRECTORY_SEPARATOR, 1) === 0) {
                 $relativefilepath = substr($relativefilepath, 1);
             }
-            
+
             if (!empty($this->get_instance()->emailfrom)) {
                 $from = core_user::get_support_user();
                 $from->email = format_string($this->get_instance()->emailfrom, true);
             } else {
                 $from = format_string($this->get_instance()->emailfrom, true);
             }
-            
+
             $ret = email_to_user($user, $from, $subject, $message, $messagehtml, $relativefilepath, $file->get_filename());
             @unlink($fullfilepath);
-            
+
             return $ret;
         } else {
             $fileinfo = self::get_certificate_issue_fileinfo($issuecert);
@@ -1086,33 +1091,33 @@ class simplecertificate {
     /**
      * Return a stores_file object with issued certificate PDF file or false otherwise
      * @param stdClass $issuecert Issued certificate object
-     * @return mixed <stored_file, boolean>   
+     * @return mixed <stored_file, boolean>
      */
     protected function get_issue_file(stdClass $issuecert) {
         //If issued certificate has change recretate certificate file
         if (!empty($issuecert->haschange)) {
             $this->save_pdf($this->create_pdf($issuecert), $issuecert);
         }
-        
+
         if (!$this->issue_file_exists($issuecert)){
             return false;
         }
-        
+
         $fs = get_file_storage();
         $fileinfo = self::get_certificate_issue_fileinfo($issuecert);
-        return $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'], 
+        return $fs->get_file($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'],
                $fileinfo['filepath'], $fileinfo['filename']);
     }
 
     /**
      * Get the time the user has spent in the course
-     * 
+     *
      * @param int $userid User ID (default= $USER->id)
      * @return int the total time spent in seconds
      */
     public function get_course_time($user = null) {
         global $CFG, $USER;
-        
+
         if (empty($user)) {
             $userid = $USER->id;
         } else {
@@ -1123,7 +1128,7 @@ class simplecertificate {
             }
         }
         set_time_limit(0);
-        
+
         $totaltime = 0;
         $sql = "l.course = :courseid AND l.userid = :userid";
         if ($logs = get_logs($sql, array('courseid' => $this->get_course()->id, 'userid' => $userid), 'l.time ASC', '', '', $totalcount)) {
@@ -1156,25 +1161,25 @@ class simplecertificate {
      */
     public function output_pdf(stdClass $issuecert) {
         global $OUTPUT;
-        
+
         if ($file = $this->get_issue_file($issuecert)) {
             switch ($this->get_instance()->delivery) {
                 case self::OUTPUT_FORCE_DOWNLOAD :
                     send_stored_file($file, 10, 0, true, array('filename' => $file->get_filename(), 'dontdie' => true)); //force download
                 break;
-                
+
                 case self::OUTPUT_SEND_EMAIL :
                     $this->send_certificade_email($issuecert);
                     echo $OUTPUT->header();
                     echo $OUTPUT->box(get_string('emailsent', 'simplecertificate') . '<br>' . $OUTPUT->close_window_button(), 'generalbox', 'notice');
                     echo $OUTPUT->footer();
                 break;
-                
+
                 case self::OUTPUT_OPEN_IN_BROWSER :
                     send_stored_file($file, 10, 0, false, array('dontdie' => true)); // open in browser
-        	    break;
+                break;
             }
-            
+
             if (has_capability('mod/simplecertificate:manage', $this->context, $issuecert->userid)) {
                 $file->delete();
             }
@@ -1187,23 +1192,24 @@ class simplecertificate {
 
     /**
      * Substitutes the certificate text variables
-     * 
+     *
      * @param stdClass $issuecert The issue certificate object
      * @param string $certtext The certificate text without substitutions
-     * @return string Return certificate text with all substutions 
+     * @return string Return certificate text with all substutions
      */
     protected function get_certificate_text($issuecert, $certtext = null) {
         global $DB, $CFG;
-        
+
         if (!$user = get_complete_user_data('id', $issuecert->userid)) {
             print_error('nousersfound', 'moodle');
         }
-        
+
         //If no text set get firstpage text
         if (empty($certtext)) {
             $certtext = $this->get_instance()->certificatetext;
         }
-        
+        $certtext = format_text($certtext, FORMAT_HTML, array('noclean' => true));
+
         $a = new stdClass();
         $a->username = fullname($user);
         $a->idnumber = $user->idnumber;
@@ -1221,39 +1227,39 @@ class simplecertificate {
         $a->department = $user->department;
         $a->address = $user->address;
         $a->city = $user->city;
-        
+
         if (!empty($user->country)) {
             $a->country = get_string($user->country, 'countries');
         } else {
             $a->country = '';
         }
-        
+
         //Formatting URL, if needed
         $url = $user->url;
         if (strpos($url, '://') === false) {
             $url = 'http://' . $url;
         }
         $a->url = $url;
-        
+
         //Getting user custom profiles fields
         $userprofilefields = $this->get_user_profile_fields($user->id);
         foreach ( $userprofilefields as $key => $value ) {
             $key = 'profile_' . $key;
             $a->$key = $value;
         }
-        
+
         $a->coursename = format_string($this->get_instance()->coursename, true);
         $a->grade = $this->get_grade($user->id);
         $a->date = $this->get_date($issuecert, $user->id);
         $a->outcome = $this->get_outcome($user->id);
         $a->certificatecode = $issuecert->code;
-        
+
         if (!empty($this->get_instance()->coursehours)) {
             $a->hours = format_string($this->get_instance()->coursehours . ' ' . get_string('hours', 'simplecertificate'), true);
         } else {
             $a->hours = '';
         }
-        
+
         try {
             if ($course = $this->get_course()) {
                 require_once ($CFG->libdir . '/coursecatlib.php');
@@ -1273,58 +1279,58 @@ class simplecertificate {
         } catch (Exception $e) {
             $a->teachers = '';
         }
-        
+
         //Fetch user actitivy restuls
         $a->userresults = $this->get_user_results($issuecert->userid);
-        
+
         $a = (array)$a;
         $search = array();
         $replace = array();
         foreach ( $a as $key => $value ) {
             $search[] = '{' . strtoupper($key) . '}';
-            $replace[] = (string)$value;
+            $replace[] = format_string((string)$value, true);
         }
-        
+
         if ($search) {
             $certtext = str_replace($search, $replace, $certtext);
         }
-        
+
         //Clear not setted custom profile fiedls {PROFILE_xxxx}
         return preg_replace('[\{PROFILE_(.*)\}]', "", $certtext);
-        
+
     }
 
     /**
      * Returns the date to display for the certificate.
-     * 
+     *
      * @param stdClass $issuecert The issue certificate object
-     * @param int $userid 
+     * @param int $userid
      * @return string the date
      */
     protected function get_date(stdClass $issuecert) {
-        global $DB; 
-        
+        global $DB;
+
         // Get date format
         if (empty($this->get_instance()->certdatefmt)) {
             $format = get_string('strftimedate', 'langconfig');
         } else {
             $format = $this->get_instance()->certdatefmt;
         }
-        
+
         //Set to current time
         $date = time();
-        
+
         // Set certificate issued date
         if ($this->get_instance()->certdate == self::CERT_ISSUE_DATE) {
             $date = $issuecert->timecreated;
         }
-        
+
         // Get the enrolment end date
         if ($this->get_instance()->certdate == self::COURSE_COMPLETATION_DATE) {
-            $sql = "SELECT MAX(c.timecompleted) as timecompleted FROM {course_completions} c 
+            $sql = "SELECT MAX(c.timecompleted) as timecompleted FROM {course_completions} c
                  WHERE c.userid = :userid AND c.course = :courseid";
-            
-            if ($timecompleted = $DB->get_record_sql($sql, array('userid' => $issuecert->userid, 
+
+            if ($timecompleted = $DB->get_record_sql($sql, array('userid' => $issuecert->userid,
                                                     'courseid' => $this->get_course()->id))) {
                 if (!empty($timecompleted->timecompleted)) {
                     $date = $timecompleted->timecompleted;
@@ -1336,43 +1342,43 @@ class simplecertificate {
                 $date = $modinfo->dategraded;
             }
         }
-        
+
         return userdate($date, $format);
     }
-    
+
     protected function get_user_results($userid = null) {
         global $USER;
-        
+
         if (empty($userid)) {
             $userid = $USER->id;
         }
-        
+
         $items = grade_item::fetch_all(array('courseid'=>$this->course->id));
         if (empty($items)) {
             return '';
         }
-        
+
         $retval = '';
         foreach($items as $id=>$item) {
            // Do not include grades for course itens
-    	   if ($item->itemtype != 'mod') {
-    		  continue;
-    	   }
-    	   $cm = get_coursemodule_from_instance($item->itemmodule, $item->iteminstance);
-    	   $usergrade = $this->get_formated_grade($this->get_mod_grade($cm->id, $userid));
-    	   $retval = $item->itemname . ": $usergrade<br>" . $retval;
+           if ($item->itemtype != 'mod') {
+              continue;
+           }
+           $cm = get_coursemodule_from_instance($item->itemmodule, $item->iteminstance);
+           $usergrade = $this->get_formated_grade($this->get_mod_grade($cm->id, $userid));
+           $retval = $item->itemname . ": $usergrade<br>" . $retval;
         }
         return $retval;
     }
 
     /**
      * Get the course outcomes for for mod_form print outcome.
-     * 
+     *
      * @return array
      */
     protected function get_outcomes() {
         global $COURSE, $DB;
-        
+
         // get all outcomes in course
         $grade_seq = new grade_tree($COURSE->id, false, true, '', false);
         if ($grade_items = $grade_seq->items) {
@@ -1393,22 +1399,22 @@ class simplecertificate {
         } else {
             $outcomeoptions['0'] = get_string('nooutcomes', 'simplecertificate');
         }
-        
+
         return $outcomeoptions;
     }
 
     /**
      * Returns the outcome to display on the certificate
-     * 
+     *
      * @return string the outcome
      */
     protected function get_outcome($userid) {
         global $USER, $DB;
-        
+
         if (empty($userid)) {
             $userid = $USER->id;
         }
-        
+
         if ($this->get_instance()->outcome > 0) {
             if ($grade_item = new grade_item(array('id' => $this->get_instance()->outcome))) {
                 $outcomeinfo = new stdClass();
@@ -1418,20 +1424,20 @@ class simplecertificate {
                 return $outcomeinfo->name . ': ' . $outcomeinfo->grade;
             }
         }
-        
+
         return '';
     }
 
     protected function create_temp_file($file) {
         global $CFG;
-        
+
         $path = make_temp_directory(self::CERTIFICATE_COMPONENT_NAME);
         return tempnam($path, $file);
     }
 
     protected function get_user_profile_fields($userid) {
         global $CFG, $DB;
-        
+
         $usercustomfields = new stdClass();
         if ($categories = $DB->get_records('user_info_category', null, 'sortorder ASC')) {
             foreach ( $categories as $category ) {
@@ -1459,21 +1465,21 @@ class simplecertificate {
 
     /**
      * Verify if user meet issue conditions
-     * 
+     *
      * @param int $userid User id
      * @return string null if user meet issued conditions, or an text with erro
      */
     protected function can_issue($user = null, $chkcompletation = true) {
         global $DB, $USER, $CFG;
-        
+
         if (empty($user)) {
             $user = $USER;
         }
-        
+
         if (has_capability('mod/simplecertificate:manage', $this->context, $user)) {
             return get_string('cantissue', 'simplecertificate');
         }
-        
+
         if ($chkcompletation) {
             $completion = new completion_info($this->course);
             if ($completion->is_enabled($this->coursemodule) && $this->get_instance()->requiredtime) {
@@ -1485,7 +1491,7 @@ class simplecertificate {
                 //Mark as complete
                 $completion->update_state($this->coursemodule, COMPLETION_COMPLETE, $user->id);
             }
-            
+
             if ($CFG->enableavailability) {
                 require_once ("{$CFG->libdir}/conditionlib.php");
                 $condition_info = new condition_info($this->coursemodule, CONDITION_MISSING_EVERYTHING);
@@ -1504,102 +1510,102 @@ class simplecertificate {
      * @return true if exist
      */
     protected function issue_file_exists(stdClass $issuecert) {
-        
+
         $fs = get_file_storage();
-        
+
         // Prepare file record object
-    	$fileinfo = self::get_certificate_issue_fileinfo($issuecert);
-        
+        $fileinfo = self::get_certificate_issue_fileinfo($issuecert);
+
         // Check for file first
-    	return $fs->file_exists($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'], 
-    	       $fileinfo['filepath'], $fileinfo['filename']);
+        return $fs->file_exists($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'],
+               $fileinfo['filepath'], $fileinfo['filename']);
     }
-    
+
     // View methods
     protected function show_tabs(moodle_url $url) {
         global $OUTPUT, $CFG;
-        
+
         $tabs[] = new tabobject(self::DEFAULT_VIEW, $url->out(false, array('tab' => self::DEFAULT_VIEW)), get_string('standardview', 'simplecertificate'));
-        
-        $tabs[] = new tabobject(self::ISSUED_CERTIFCADES_VIEW, $url->out(false, array('tab' => self::ISSUED_CERTIFCADES_VIEW)), 
+
+        $tabs[] = new tabobject(self::ISSUED_CERTIFCADES_VIEW, $url->out(false, array('tab' => self::ISSUED_CERTIFCADES_VIEW)),
                 get_string('issuedview', 'simplecertificate'));
-        
-        $tabs[] = new tabobject(self::BULK_ISSUE_CERTIFCADES_VIEW, $url->out(false, array('tab' => self::BULK_ISSUE_CERTIFCADES_VIEW)), 
+
+        $tabs[] = new tabobject(self::BULK_ISSUE_CERTIFCADES_VIEW, $url->out(false, array('tab' => self::BULK_ISSUE_CERTIFCADES_VIEW)),
                 get_string('bulkview', 'simplecertificate'));
-        
+
         if (!$url->get_param('tab')) {
             $tab = self::DEFAULT_VIEW;
         } else {
             $tab = $url->get_param('tab');
         }
-        
+
         echo $OUTPUT->tabtree($tabs, $tab);
-    
+
     }
-    
+
     // Default view
     public function view_default(moodle_url $url, $canmanage) {
         global $CFG, $OUTPUT, $USER;
-        
+
         if (!$url->get_param('action')) {
-            
+
             echo $OUTPUT->header();
-            
+
             if ($canmanage) {
                 $this->show_tabs($url);
             }
-            
+
             // Check if the user can view the certificate
-    		if (!$canmanage && $msg = $this->can_issue($USER)) {
+            if (!$canmanage && $msg = $this->can_issue($USER)) {
                 notice($msg, $CFG->wwwroot . '/course/view.php?id=' . $this->get_course()->id, $this->get_course());
                 die();
             }
-            
+
             if (!empty($this->get_instance()->intro)) {
-                echo $OUTPUT->box(format_module_intro('simplecertificate', $this->get_instance(), $this->coursemodule->id), 'generalbox', 
+                echo $OUTPUT->box(format_module_intro('simplecertificate', $this->get_instance(), $this->coursemodule->id), 'generalbox',
                                   'intro');
             }
-            
+
             if ($attempts = $this->get_attempts()) {
                 echo $this->print_attempts($attempts);
             }
-            
+
             if (!$canmanage) {
                 //TODO create a funciton add_log
                 add_to_log($this->get_course()->id, 'simplecertificate', 'view', $url->out_as_local_url(false), $this->get_instance()->id,
                           $this->coursemodule->id);
             }
-            
+
             if ($this->get_instance()->delivery != 3 || $canmanage) {
                 // Create new certificate record, or return existing record
-    		 
-    			$certrecord = $this->get_issue();
+
+                $certrecord = $this->get_issue();
                 switch ($this->get_instance()->delivery) {
                     case self::OUTPUT_FORCE_DOWNLOAD :
                         $str = get_string('opendownload', 'simplecertificate');
                     break;
-                    
+
                     case self::OUTPUT_SEND_EMAIL :
                         $str = get_string('openemail', 'simplecertificate');
                     break;
-                    
+
                     default :
                         $str = get_string('openwindow', 'simplecertificate');
                     break;
                 }
-                
+
                 echo html_writer::tag('p', $str, array('style' => 'text-align:center'));
                 $linkname = get_string('getcertificate', 'simplecertificate');
-                
+
                 $link = new moodle_url('/mod/simplecertificate/view.php', array('id' => $this->coursemodule->id, 'action' => 'get'));
                 $button = new single_button($link, $linkname);
                 $button->add_action(new popup_action('click', $link, 'view' . $this->coursemodule->id, array('height' => 600, 'width' => 800)));
-                
+
                 echo html_writer::tag('div', $OUTPUT->render($button), array('style' => 'text-align:center'));
             }
             echo $OUTPUT->footer();
         } else { // Output to pdf
-	 		if ($this->get_instance()->delivery != 3 || $canmanage) {
+             if ($this->get_instance()->delivery != 3 || $canmanage) {
                 $this->output_pdf($this->get_issue($USER));
             }
         }
@@ -1607,19 +1613,19 @@ class simplecertificate {
 
     protected function get_issued_certificate_users($sort = "ci.timecreated ASC", $groupmode = 0, $page = 0, $perpage = self::SIMPLECERT_MAX_PER_PAGE) {
         global $CFG, $DB;
-        
+
         // get all users that can manage this certificate to exclude them from the report.
-		$certmanagers = get_users_by_capability($this->context, 'mod/simplecertificate:manage', 'u.id');
+        $certmanagers = get_users_by_capability($this->context, 'mod/simplecertificate:manage', 'u.id');
         $limitsql = '';
         $page = (int)$page;
         $perpage = (int)$perpage;
-        
+
         // Setup pagination - when both $page and $perpage = 0, get all results
-		if ($page || $perpage) {
+        if ($page || $perpage) {
             if ($page < 0) {
                 $page = 0;
             }
-            
+
             if ($perpage > self::SIMPLECERT_MAX_PER_PAGE) {
                 $perpage = self::SIMPLECERT_MAX_PER_PAGE;
             } else {
@@ -1627,32 +1633,32 @@ class simplecertificate {
             }
             $limitsql = " LIMIT $perpage" . " OFFSET " . $page * $perpage;
         }
-        
+
         // Get all the users that have certificates issued, should only be one issue per user for a certificate
-		$issedusers = $DB->get_records_sql("SELECT u.*, ci.code, ci.timecreated
-				FROM {user} u
-				INNER JOIN {simplecertificate_issues} ci
-				ON u.id = ci.userid
-				WHERE u.deleted = 0
-				AND ci.certificateid = :certificateid
-				AND timedeleted IS NULL
-				ORDER BY {$sort} {$limitsql}", array('certificateid' => $this->get_instance()->id
+        $issedusers = $DB->get_records_sql("SELECT u.*, ci.code, ci.timecreated
+                FROM {user} u
+                INNER JOIN {simplecertificate_issues} ci
+                ON u.id = ci.userid
+                WHERE u.deleted = 0
+                AND ci.certificateid = :certificateid
+                AND timedeleted IS NULL
+                ORDER BY {$sort} {$limitsql}", array('certificateid' => $this->get_instance()->id
         ));
-        
+
         // now exclude all the certmanagers.
-		foreach ( $issedusers as $id => $user ) {
+        foreach ( $issedusers as $id => $user ) {
             if (!empty($certmanagers[$id])) { //exclude certmanagers.
-				unset($issedusers[$id]);
+                unset($issedusers[$id]);
             }
         }
-        
+
         // if groupmembersonly used, remove users who are not in any group
-		if (!empty($issedusers) and !empty($CFG->enablegroupings) and $this->coursemodule->groupmembersonly) {
+        if (!empty($issedusers) and !empty($CFG->enablegroupings) and $this->coursemodule->groupmembersonly) {
             if ($groupingusers = groups_get_grouping_members($cm->groupingid, 'u.id', 'u.id')) {
                 $issedusers = array_intersect($issedusers, array_keys($groupingusers));
             }
         }
-        
+
         if ($groupmode) {
             $currentgroup = groups_get_activity_group($this->coursemodule);
             if ($currentgroup) {
@@ -1663,7 +1669,7 @@ class simplecertificate {
                 foreach ( $issedusers as $id => $unused ) {
                     if (empty($groupusers[$id])) {
                         // remove this user as it isn't in the group!
-						unset($issedusers[$id]);
+                        unset($issedusers[$id]);
                     }
                 }
             }
@@ -1678,35 +1684,35 @@ class simplecertificate {
     */
     protected function print_issue_certificate_file(stdClass $issuecert) {
         global $CFG, $OUTPUT;
-        
+
         $output = '';
-        
+
         $fs = get_file_storage();
         $fileinfo = simplecertificate::get_certificate_issue_fileinfo($issuecert);
-        if (!$fs->file_exists($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'], 
+        if (!$fs->file_exists($fileinfo['contextid'], $fileinfo['component'], $fileinfo['filearea'], $fileinfo['itemid'],
             $fileinfo['filepath'], $fileinfo['filename'])) {
             return $output;
         }
-        
-        $link = moodle_url::make_pluginfile_url($this->get_context()->id, self::CERTIFICATE_COMPONENT_NAME, $fileinfo['filearea'], 
+
+        $link = moodle_url::make_pluginfile_url($this->get_context()->id, self::CERTIFICATE_COMPONENT_NAME, $fileinfo['filearea'],
                             $issuecert->id, $fileinfo['filepath'], $fileinfo['filename'], true);
-        
+
         $mimetype = $fileinfo['mimetype'];
-        $output = '<img src="' . $OUTPUT->pix_url(file_mimetype_icon($mimetype)) . '" height="16" width="16" alt="' . $mimetype . 
+        $output = '<img src="' . $OUTPUT->pix_url(file_mimetype_icon($mimetype)) . '" height="16" width="16" alt="' . $mimetype .
                 '" />&nbsp;' . '<a href="' . $link->out(false) . '" target="_blank" >' . s($fileinfo['filename']) . '</a>';
-        
+
         $output .= '<br />';
         $output = '<div class="files">' . $output . '</div>';
-        
+
         return $output;
     }
-    
+
     // Issued certificates view
     public function view_issued_certificates(moodle_url $url) {
         global $OUTPUT, $DB, $CFG;
-        
+
         // Declare some variables
-    	$strcertificates = get_string('modulenameplural', 'simplecertificate');
+        $strcertificates = get_string('modulenameplural', 'simplecertificate');
         $strcertificate = get_string('modulename', 'simplecertificate');
         $strto = get_string('awardedto', 'simplecertificate');
         $strdate = get_string('receiveddate', 'simplecertificate');
@@ -1716,29 +1722,29 @@ class simplecertificate {
         $groupmode = groups_get_activity_groupmode($this->get_course_module());
         $page = $url->get_param('page');
         $perpage = $url->get_param('perpage');
-        
+
         $users = $this->get_issued_certificate_users($DB->sql_fullname(), $groupmode, $page, $perpage);
-        
+
         if (!$url->get_param('action')) {
             echo $OUTPUT->header();
             $this->show_tabs($url);
-            
+
             if ($groupmode) {
                 groups_get_activity_group($this->coursemodule, true);
             }
-            
+
             groups_print_activity_menu($this->coursemodule, $url);
-            
+
             if (!$users) {
                 notify(get_string('nocertificatesissued', 'simplecertificate'));
                 echo $OUTPUT->footer();
                 exit();
             }
-            
+
             $usercount = count($users);
-            
+
             // Create the table for the users
-    		$table = new html_table();
+            $table = new html_table();
             $table->width = "95%";
             $table->tablealign = "center";
             $table->head = array($strto, $strdate, $strgrade, $strcode);
@@ -1749,52 +1755,52 @@ class simplecertificate {
                 $code = $user->code;
                 $table->data[] = array($name, $date, $this->get_grade($user->id), $code);
             }
-            
+
             // Create table to store buttons
-    		$tablebutton = new html_table();
+            $tablebutton = new html_table();
             $tablebutton->attributes['class'] = 'downloadreport';
-            
-    		$btndownloadods = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'ods')), 
-    		                                        get_string("downloadods"));
-            $btndownloadxls = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'xls')), 
+
+            $btndownloadods = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'ods')),
+                                                    get_string("downloadods"));
+            $btndownloadxls = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'xls')),
                                                     get_string("downloadexcel"));
-            $btndownloadtxt = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'txt')), 
+            $btndownloadtxt = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download', 'type' => 'txt')),
                                                     get_string("downloadtext"));
             $tablebutton->data[] = array($btndownloadods, $btndownloadxls, $btndownloadtxt);
-            
-    		echo $OUTPUT->paging_bar($usercount, $page, $perpage, $url);
+
+            echo $OUTPUT->paging_bar($usercount, $page, $perpage, $url);
             echo '<br />';
             echo html_writer::table($table);
             echo html_writer::tag('div', html_writer::table($tablebutton), array('style' => 'margin:auto; width:50%'));
-        
+
         } else if ($url->get_param('action') == 'download') {
             $page = $perpage = 0;
             $type = $url->get_param('type');
             // Calculate file name
-    		$filename = clean_filename($this->get_instance()->coursename . '-' . strip_tags(format_string($this->get_instance()->name, true)) . 
-    		                          '.' . strip_tags(format_string($type, true)));
-            
+            $filename = clean_filename($this->get_instance()->coursename . '-' . strip_tags(format_string($this->get_instance()->name, true)) .
+                                      '.' . strip_tags(format_string($type, true)));
+
             switch ($type) {
                 case 'ods' :
                     require_once ("$CFG->libdir/odslib.class.php");
-                    
+
                     // Creating a workbook
-    		    	$workbook = new MoodleODSWorkbook("-");
+                    $workbook = new MoodleODSWorkbook("-");
                     // Send HTTP headers
-    		    	$workbook->send($filename);
+                    $workbook->send(format_text($filename, true));
                     // Creating the first worksheet
-    		    	$myxls = $workbook->add_worksheet($strreport);
-                    
+                    $myxls = $workbook->add_worksheet($strreport);
+
                     // Print names of all the fields
-    		    	$myxls->write_string(0, 0, get_string("fullname"));
+                    $myxls->write_string(0, 0, get_string("fullname"));
                     $myxls->write_string(0, 1, get_string("idnumber"));
                     $myxls->write_string(0, 2, get_string("group"));
                     $myxls->write_string(0, 3, $strdate);
                     $myxls->write_string(0, 4, $strgrade);
                     $myxls->write_string(0, 5, $strcode);
-                    
+
                     // Generate the data for the body of the spreadsheet
-    		    	$i = 0;
+                    $i = 0;
                     $row = 1;
                     if ($users) {
                         foreach ( $users as $user ) {
@@ -1816,29 +1822,29 @@ class simplecertificate {
                         $pos = 5;
                     }
                     // Close the workbook
-    		    	$workbook->close();
+                    $workbook->close();
                 break;
-                
+
                 case 'xls' :
                     require_once ("$CFG->libdir/excellib.class.php");
-                    
+
                     // Creating a workbook
-    		    	$workbook = new MoodleExcelWorkbook("-");
+                    $workbook = new MoodleExcelWorkbook("-");
                     // Send HTTP headers
-    		    	$workbook->send($filename);
+                    $workbook->send(format_text($filename, true));
                     // Creating the first worksheet
-    		    	$myxls = $workbook->add_worksheet($strreport);
-                    
+                    $myxls = $workbook->add_worksheet($strreport);
+
                     // Print names of all the fields
-    		    	$myxls->write_string(0, 0, get_string("fullname"));
+                    $myxls->write_string(0, 0, get_string("fullname"));
                     $myxls->write_string(0, 1, get_string("idnumber"));
                     $myxls->write_string(0, 2, get_string("group"));
                     $myxls->write_string(0, 3, $strdate);
                     $myxls->write_string(0, 4, $strgrade);
                     $myxls->write_string(0, 5, $strcode);
-                    
+
                     // Generate the data for the body of the spreadsheet
-    		    	$i = 0;
+                    $i = 0;
                     $row = 1;
                     if ($users) {
                         foreach ( $users as $user ) {
@@ -1860,26 +1866,26 @@ class simplecertificate {
                         $pos = 5;
                     }
                     // Close the workbook
-    		    	$workbook->close();
+                    $workbook->close();
                 break;
-                
+
                 case 'txt' :
-                    
+
                     header("Content-Type: application/download\n");
-                    header("Content-Disposition: attachment; filename=\"$filename\"");
+                    header("Content-Disposition: attachment; filename=\"".format_text($filename, true)."\"");
                     header("Expires: 0");
                     header("Cache-Control: must-revalidate,post-check=0,pre-check=0");
                     header("Pragma: public");
-                    
+
                     // Print names of all the fields
-    		    	echo get_string("fullname") . "\t" . get_string("idnumber") . "\t";
+                    echo get_string("fullname") . "\t" . get_string("idnumber") . "\t";
                     echo get_string("group") . "\t";
                     echo $strdate . "\t";
                     echo $strgrade . "\t";
                     echo $strcode . "\n";
-                    
+
                     // Generate the data for the body of the spreadsheet
-    		    	$i = 0;
+                    $i = 0;
                     $row = 1;
                     if ($users)
                         foreach ( $users as $user ) {
@@ -1910,9 +1916,9 @@ class simplecertificate {
 
     public function view_bulk_certificates(moodle_url $url, array $selectedusers = null) {
         global $OUTPUT, $CFG, $DB;
-        
+
         $course_context = context_course::instance($this->get_course()->id);
-        
+
         $page = $url->get_param('page');
         $perpage = $url->get_param('perpage');
         $issuelist = $url->get_param('issuelist');
@@ -1923,26 +1929,26 @@ class simplecertificate {
             $groupid = groups_get_activity_group($this->coursemodule, true);
         }
 
-		$page_start = intval($page * $perpage);
-		$usercount = 0;
+        $page_start = intval($page * $perpage);
+        $usercount = 0;
         if (!$selectedusers) {
-			$users = get_enrolled_users($course_context, '', $groupid);
-			$usercount = count($users);
-			$users = array_slice($users, $page_start, $perpage);
+            $users = get_enrolled_users($course_context, '', $groupid);
+            $usercount = count($users);
+            $users = array_slice($users, $page_start, $perpage);
         } else {
             list($sqluserids, $params) = $DB->get_in_or_equal($selectedusers);
             $sql = "SELECT * FROM {user} WHERE id $sqluserids";
             $users = $DB->get_records_sql($sql, $params);
         }
-        
+
         if (!$action) {
             echo $OUTPUT->header();
             $this->show_tabs($url);
-            
+
             groups_print_activity_menu($this->coursemodule, $url);
-            
-            
-            $selectoptions = array('completed' => get_string('completedusers', 'simplecertificate'), 
+
+
+            $selectoptions = array('completed' => get_string('completedusers', 'simplecertificate'),
                             'allusers' => get_string('allusers', 'simplecertificate')
             );
             $select = new single_select($url, 'issuelist', $selectoptions, $issuelist);
@@ -1950,7 +1956,7 @@ class simplecertificate {
             echo $OUTPUT->render($select);
             echo '<br>';
             echo '<form id="bulkissue" name="bulkissue" method="post" action="view.php">';
-            
+
             echo html_writer::label(get_string('bulkaction', 'simplecertificate'), 'menutype', true);
             echo '&nbsp;';
             $selectoptions = array('pdf'=>get_string('onepdf', 'simplecertificate'),
@@ -1961,9 +1967,9 @@ class simplecertificate {
             $table = new html_table();
             $table->width = "95%";
             $table->tablealign = "center";
-            
+
             //strgrade
-    		$table->head = array(' ', get_string('fullname'), get_string('grade'));
+            $table->head = array(' ', get_string('fullname'), get_string('grade'));
             $table->align = array("left", "left", "center");
             $table->size = array('1%', '89%', '10%');
             foreach ( $users as $user ) {
@@ -1975,29 +1981,29 @@ class simplecertificate {
                     );
                 }
             }
-            
-            $downloadbutton = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download')), 
+
+            $downloadbutton = $OUTPUT->single_button($url->out_as_local_url(false, array('action' => 'download')),
                             get_string('bulkbuttonlabel', 'simplecertificate'));
-            
+
             echo $OUTPUT->paging_bar($usercount, $page, $perpage, $url);
             echo '<br />';
             echo html_writer::table($table);
             echo html_writer::tag('div', $downloadbutton, array('style' => 'text-align: center'));
             echo '</form>';
-        
+
         } else if ($action == 'download') {
             $type = $url->get_param('type');
-            
+
             // Calculate file name
-    		$filename = str_replace(' ', '_', clean_filename($this->get_instance()->coursename . ' ' . 
-    		          get_string('modulenameplural', 'simplecertificate') . ' ' . strip_tags(format_string($this->get_instance()->name, true)) . 
-    		          '.' . strip_tags(format_string($type, true))));
-            
+            $filename = str_replace(' ', '_', clean_filename($this->get_instance()->coursename . ' ' .
+                      get_string('modulenameplural', 'simplecertificate') . ' ' . strip_tags(format_string($this->get_instance()->name, true)) .
+                      '.' . strip_tags(format_string($type, true))));
+
             switch ($type) {
                 //One pdf with all certificates
-    		    case 'pdf':
+                case 'pdf':
                     $pdf = $this->create_pdf_object();
-                    
+
                     foreach ( $users as $user ) {
                         $canissue = $this->can_issue($user, $issuelist != 'allusers');
                         if (empty($canissue)) {
@@ -2005,11 +2011,11 @@ class simplecertificate {
                         }
                     }
                     $pdf->Output($filename, 'D');
-                
+
                 break;
-                
+
                 //One zip with all certificates in separated files
-    		    case 'zip':
+                case 'zip':
                     $filesforzipping = array();
                     foreach ( $users as $user ) {
                         $canissue = $this->can_issue($user, $issuelist != 'allusers');
@@ -2025,17 +2031,17 @@ class simplecertificate {
                             }
                         }
                     }
-                    
+
                     $tempzip = $this->create_temp_file('issuedcertificate_');
-                    
+
                     //zipping files
-    		    	$zipper = new zip_packer();
+                    $zipper = new zip_packer();
                     if ($zipper->archive_to_pathname($filesforzipping, $tempzip)) {
                         //send file and delete after sending.
-    		    		send_temp_file($tempzip, $filename);
+                        send_temp_file($tempzip, $filename);
                     }
                 break;
-                
+
                 case 'email':
                     foreach ( $users as $user ) {
                         $canissue = $this->can_issue($user, $issuelist != 'allusers');


### PR DESCRIPTION
This fixes the following issues:

1) Adds output filtering (e.g. multilingual filter) when rendering the PDF certificate in the certificate, the tags and in the PDF document properties.

2) Fixes the keyword list in the PDF so that it don't end up with a duplicate string separated by a semi-colon (;).

3) Adds output filtering (e.g. multilingual filter) of download filenames of Issued Certificate in ODS, Excel and Text format.

4) Corrects some spelling typos and formatting issues in the English language file.

5) Replaced tabs with 4 spaces and removed trailing spaces.

Affected files include:
- locallib.php
- lang/en/simplecertificate.php

Signed-off-by: Michael Milette michael.milette@instruxmedia.com
