### PR TITLE
 Send issued certificates to teacher's email too #130 

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -26,8 +26,9 @@
                 <FIELD NAME="certgrade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="certdatefmt" NEXT="gradefmt"/>
                 <FIELD NAME="gradefmt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="certgrade" NEXT="emailfrom"/>
                 <FIELD NAME="emailfrom" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="gradefmt" NEXT="emailothers"/>
-                <FIELD NAME="emailothers" TYPE="text" NOTNULL="false" SEQUENCE="false" PREVIOUS="emailfrom" NEXT="emailteachers"/>
-                <FIELD NAME="emailteachers" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="emailothers" NEXT="reportcert"/>
+                <FIELD NAME="emailothers" TYPE="text" NOTNULL="false" SEQUENCE="false" PREVIOUS="emailfrom" NEXT="cert2teacher"/>
+                <FIELD NAME="cert2teacher" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" PREVIOUS="emailothers" NEXT="emailteachers"/>
+                <FIELD NAME="emailteachers" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="cert2teacher" NEXT="reportcert"/>
                 <FIELD NAME="reportcert" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="emailteachers" NEXT="delivery"/>
                 <FIELD NAME="delivery" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="reportcert" NEXT="requiredtime"/>
                 <FIELD NAME="requiredtime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" PREVIOUS="delivery" NEXT="printqrcode"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -21,6 +21,14 @@ function xmldb_simplecertificate_upgrade($oldversion=0) {
     global $CFG, $DB, $OUTPUT;
     
     $dbman = $DB->get_manager();
+
+    // add cert2teacher option
+    $table = new xmldb_table('simplecertificate');
+    $field = new xmldb_field('cert2teacher', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'cert2teacher');
+    if (!$dbman->field_exists($table, $field)) {
+        $dbman->add_field($table, $field);
+    }
+
     if ($oldversion < 2013053102) {
 
         $table = new xmldb_table('simplecertificate');

--- a/lang/en/simplecertificate.php
+++ b/lang/en/simplecertificate.php
@@ -213,6 +213,8 @@ $string['defaultcertificatetextx'] = 'Default Horizontal Text Position';
 $string['defaultcertificatetexty'] = 'Default Vertical Text Position';
 
 
+
+
 //Erros
 $string['filenotfound'] = 'File not Found';
 $string['invalidcode'] = 'Invalid certificate code';
@@ -226,6 +228,9 @@ $string['certificateverification'] = 'Certificate Verification';
 //Settings
 $string['certlifetime'] = 'Keep issued certificates for: (in Months)';
 $string['certlifetime_help'] = 'This specifies the length of time you want to keep issued certificates. Issued certificates that are older than this age are automatically deleted.';
+$string['cert2teacher'] = 'Send individual copies of each cert to Teachers';
+$string['cert2teacher_help'] = 'When students generate their certificate this setting will email Teachers for each course when sending students their copy.';
+
 $string['neverdeleteoption'] = 'Never delete';
 
 $string['variablesoptions'] = 'Others Options';

--- a/lang/en/simplecertificate.php
+++ b/lang/en/simplecertificate.php
@@ -179,6 +179,15 @@ Hello {$a->username},
 
 THIS IS AN AUTOMATED MESSAGE - PLEASE DO NOT REPLY';
 
+$string['emailstudentsubjectteacher'] = '{$a->username} has completed {$a->course}';
+$string['emailstudenttextteacher'] = '
+Hello,
+
+The student {$a->username} has completed {$a->course} and a certificate has been issued.
+
+It has been attached to this email for your records.
+
+THIS IS AN AUTOMATED MESSAGE - PLEASE DO NOT REPLY';
 $string['emailteachermail'] = '
 {$a->student} has received their certificate: \'{$a->certificate}\'
 for {$a->course}.

--- a/locallib.php
+++ b/locallib.php
@@ -1191,14 +1191,15 @@ class simplecertificate {
             } else {
                 $from = format_string($this->get_instance()->emailfrom, true);
             }
-            
+
             // Email student
             $ret = email_to_user($user, $from, $subject, $message, $messagehtml, $relativefilepath, $file->get_filename());
 
-            foreach ($this->get_teachers() as $teacher) {
-                $tmpmail = $teacher->user->email;
-                // Email teacher
-                @email_to_user($tmpmail, $from, $tchsubject, $message, $messagehtml, $relativefilepath, $file->get_filename());
+            // Email teacher when cert2teacher enabled
+            if ($this->get_instance()->cert2teacher == 1) {
+                foreach ($this->get_teachers() as $teacher) {
+                    $tmpmail = $teacher->user->email;
+                    @email_to_user($tmpmail, $from, $tchsubject, $message, $messagehtml, $relativefilepath, $file->get_filename());
                 }
             }
             @unlink($fullfilepath);

--- a/locallib.php
+++ b/locallib.php
@@ -1165,8 +1165,12 @@ class simplecertificate {
         $info->certificate = format_string($issuecert->certificatename, true);
         $info->course = format_string($this->get_instance()->coursename, true);
         
+        // Details to send to student
         $subject = get_string('emailstudentsubject', 'simplecertificate', $info);
         $message = get_string('emailstudenttext', 'simplecertificate', $info) . "\n";
+        // Details to send to teachers
+        $tchsubject = get_string('emailstudentsubjectteacher', 'simplecertificate', $info);
+        $tchmessage = get_string('emailstudenttextteacher', 'simplecertificate', $info) . "\n";
         
         // Make the HTML version more XHTML happy  (&amp;)
         $messagehtml = text_to_html($message);
@@ -1188,7 +1192,15 @@ class simplecertificate {
                 $from = format_string($this->get_instance()->emailfrom, true);
             }
             
+            // Email student
             $ret = email_to_user($user, $from, $subject, $message, $messagehtml, $relativefilepath, $file->get_filename());
+
+            foreach ($this->get_teachers() as $teacher) {
+                $tmpmail = $teacher->user->email;
+                // Email teacher
+                @email_to_user($tmpmail, $from, $tchsubject, $message, $messagehtml, $relativefilepath, $file->get_filename());
+                }
+            }
             @unlink($fullfilepath);
             
             return $ret;

--- a/settings.php
+++ b/settings.php
@@ -29,6 +29,9 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configselect('simplecertificate/certdate', get_string('printdate', 'simplecertificate'),
         get_string('printdate_help', 'simplecertificate'), -2, simplecertificate_get_date_options()));
 
+    // Setting to include teachers in certificate completion emails
+    $settings->add(new admin_setting_configcheckbox('simplecertificate/cert2teacher', get_string('cert2teacher', 'simplecertificate'),
+		get_string('cert2teacher_help', 'simplecertificate'), 1));
 
     $settings->add(new admin_setting_configtext('simplecertificate/certlifetime', get_string('certlifetime', 'simplecertificate'),
         get_string('certlifetime_help', 'simplecertificate'), 60, PARAM_INT));


### PR DESCRIPTION
I think i've done this correctly, please let me know if i've missed anything. (This is my first moodle plugin edit.)

This pull request should close this bug/request 
Send issued certificates to teacher's email too #130 

It will:
- Allow the pdf certificate that is sent to students to be sent to class teachers as well.
- It has an option to turn it on or off in the plugin settings.
- It has install and upgrade check in the script
- strings are separated from the student email strings and will only run when enabled by the plugin.

Please check my code out and make any changes you would like.

I think it might be a good idea to only set $tchsubject and $tchmessage inside the ($this->get_instance()->cert2teacher == 1) section but i only realised this when i'd finished typing...
