### PR TITLE
The  filter auto generated links was removed in the certificate text

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1339,7 +1339,9 @@ class simplecertificate {
         if (empty($certtext)) {
             $certtext = $this->get_instance()->certificatetext;
         }
-        $certtext = format_text($certtext, FORMAT_HTML, array('noclean' => true));
+        // Due #111 improvement
+        // The  filter auto generated links was removed in the certificate text
+        $certtext = format_text($certtext, FORMAT_HTML, array('filter' => false, 'noclean' => true));
         
         $a = new stdClass();
         $a->username = fullname($user);


### PR DESCRIPTION
This pull request refers to issue [#111](
https://github.com/bozoh/moodle-mod_simplecertificate/issues/111) (improvement)