### PR TITLE
upgrade 2.2.4 to 2.2.5  - fix for error

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -389,7 +389,7 @@ function xmldb_simplecertificate_upgrade($oldversion=0) {
       $table = new xmldb_table('simplecertificate_issues');
     
       // <FIELD NAME="coursename" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="pathnamehash" />
-      $field = new xmldb_field('coursename', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, '', 'pathnamehash');
+      $field = new xmldb_field('coursename', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null , 'pathnamehash');
     
 
       if (!$dbman->field_exists($table, $field)) {


### PR DESCRIPTION
Fix for the upgrade error. error message: "XMLDB has detected one CHAR NOT NULL column (coursename) with '' (empty string) as DEFAULT value. This type of columns must have one meaningful DEFAULT declared or none (NULL). XMLDB have fixed it automatically changing it to none (NULL). The process will continue ok and proper defaults will be created accordingly with each DB requirements. Please fix it in source (XML and/or upgrade script) to avoid this message to be displayed."