### PR TITLE
Adds option to use course start date as a date {DATE} option 

### DIFF
--- a/lang/en/simplecertificate.php
+++ b/lang/en/simplecertificate.php
@@ -69,6 +69,7 @@ $string['defaultcodey'] = 'Default Vertical QR code Position';
 ////Date options
 $string['issueddate'] = 'Date Issued';
 $string['completiondate'] = 'Course Completion';
+$string['coursestartdate'] = 'Course Start Date';
 $string['datefmt'] = 'Date Format';
 
 ////Date format options

--- a/lib.php
+++ b/lib.php
@@ -432,6 +432,7 @@ function simplecertificate_get_date_options() {
     require_once (dirname(__FILE__) . '/locallib.php');
     $dateoptions[simplecertificate::CERT_ISSUE_DATE] = get_string('issueddate', 'simplecertificate');
     $dateoptions[simplecertificate::COURSE_COMPLETATION_DATE] = get_string('completiondate', 'simplecertificate');
+    $dateoptions[simplecertificate::COURSE_START_DATE] = get_string('coursestartdate', 'simplecertificate');
     return $dateoptions + simplecertificate_get_mods();
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -57,6 +57,7 @@ class simplecertificate {
     // Date Options Const
     const CERT_ISSUE_DATE = -1;
     const COURSE_COMPLETATION_DATE = -2;
+    const COURSE_START_DATE = -3;
     
     // Grade Option Const
     const NO_GRADE = 0;
@@ -1529,6 +1530,15 @@ class simplecertificate {
         // Set certificate issued date
         if ($this->get_instance()->certdate == self::CERT_ISSUE_DATE) {
             $date = $issuecert->timecreated;
+        }
+        
+        // Get the course start date
+        if ($this->get_instance()->certdate == self::COURSE_START_DATE) {
+        			$sql = "SELECT id, startdate FROM {course} c
+              WHERE c.id = :courseid";
+			
+        $coursestartdate = $DB->get_record_sql($sql, array('courseid' => $this->get_course()->id));
+        $date = $coursestartdate->startdate;
         }
         
         // Get the enrolment end date


### PR DESCRIPTION
Gets the start date of the current course and adds a new option in 'Print Date' select for Course Start Date. This is particularly useful for us as we do a lot of in-person training, and this token makes our certificate templates re-usable now.  Issue #166 (Improvement)
