### PR TITLE
fix (custom fields)!: the text can use basic html

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1397,7 +1397,7 @@ class simplecertificate {
         $userprofilefields = $this->get_user_profile_fields($user->id);
         foreach ($userprofilefields as $key => $value) {
             $key = 'profile_' . $key;
-            $a->$key = strip_tags($value);
+            $a->$key = $value;
         }
         // The course name never change form a certificate to another, useless
         // text mark and atribbute, can be removed.


### PR DESCRIPTION
According to the documentation, the use of html in custom fields must be allowed.

https://github.com/bozoh/moodle-mod_simplecertificate/blob/c65cd5ea12005d6c221df54ebedb69bc4262256e/lang/en/simplecertificate.php#L146
https://github.com/bozoh/moodle-mod_simplecertificate/blob/c65cd5ea12005d6c221df54ebedb69bc4262256e/lang/pt_br/simplecertificate.php#L148