### PR TITLE
[3.11] Change language string

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -691,7 +691,7 @@ class simplecertificate {
         $gradecolumn = $this->get_instance()->certgrade;
 
         if ($gradecolumn) {
-            $table->head[] = get_string('grade');
+            $table->head[] = get_string('grade', 'simplecertificate');
             $table->align[] = 'center';
             $table->size[] = '';
         }
@@ -2326,7 +2326,7 @@ class simplecertificate {
             $table = new html_table();
             $table->width = "95%";
             $table->tablealign = "center";
-            $table->head = array(' ', get_string('fullname'), get_string('grade'));
+            $table->head = array(' ', get_string('fullname'), get_string('grade', 'simplecertificate'));
             $table->align = array("left", "left", "center");
             $table->size = array('1%', '89%', '10%');
 

--- a/locallib.php
+++ b/locallib.php
@@ -2024,7 +2024,7 @@ class simplecertificate {
             $table->width = "95%";
             $table->tablealign = "center";
 
-            $table->head = array(' ', get_string('fullname'), get_string('grade'));
+            $table->head = array(' ', get_string('fullname'), get_string('grade', 'simplecertificate'));
             $table->align = array("left", "left", "center");
             $table->size = array('1%', '89%', '10%');
 


### PR DESCRIPTION
String [grade,core] is deprecated. Either you should no longer be using that string, or the string has been incorrectly deprecated, in which case you should report this as a bug. Please refer to https://docs.moodle.org/dev/String_deprecation
line 394 of /lib/classes/string_manager_standard.php: call to debugging()
line 7278 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
line 2027 of /mod/simplecertificate/locallib.php: call to get_string()
line 105 of /mod/simplecertificate/view.php: call to simplecertificate->view_issued_certificates()