### PR TITLE
Issue #287: Updated locallib_test to fix errors

### DIFF
--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -42,6 +42,7 @@ class locallib_test extends mod_simplecertificate_base_testcase {
 
     public function test_create_instance() {
         global $DB;
+        $this->resetAfterTest(true);
 
         // Basic CRUD test.
         $this->assertFalse($DB->record_exists('simplecertificate',['course' => $this->course->id]));
@@ -242,7 +243,7 @@ class locallib_test extends mod_simplecertificate_base_testcase {
         $issuecert1 = $cert->get_issue($this->students[0]);
 
         // Verify if timedelete is really null.
-        $this->assertObjectNotHasAttribute('timedeleted', $issuecert1);
+        $this->assertObjectNotHasProperty('timedeleted', $issuecert1);
 
         // Update simplecertificate instance.
         $cert->delete_instance($cert->get_instance());
@@ -251,7 +252,7 @@ class locallib_test extends mod_simplecertificate_base_testcase {
         // Verify if timedelete is not null.
         $issuecert1 = $DB->get_record('simplecertificate_issues',['id' => $issuecert1->id]);
 
-        $this->assertObjectHasAttribute('timedeleted', $issuecert1);
+        $this->assertObjectHasProperty('timedeleted', $issuecert1);
     }
 
     // DOn't work with moodle 3.0.


### PR DESCRIPTION
Closes Issue #287.

This fix is small update to `locallib_test.php` that gets rid of the errors presented in #287.

**How to test**
1. Deploy instance of Moodle 4.5 with mod_simplecertificate (branch: master) installed.
2. Initialize PHP Unit testing environment.
3. Run vendor/bin/phpunit mod/simplecertificate/tests/locallib_test.php
4. See the error
5. Apply the fix from `main-issue287` branch
6. Re-run the test and see the error and warnings are resolved:
```
Moodle 4.5.3 (Build: 20250317), 2b9c1b4c1a5e73695ded65e941b4af0c596c2c05
Php: 8.1.28, mysqli: 8.0.37, OS: Linux 6.8.0-57-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.............                                                     13 / 13 (100%)

Time: 01:00.015, Memory: 121.30 MB

OK (13 tests, 57 assertions)
```