### PR TITLE
Ensure issued certificate codes are unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Place this folder in your mod folder in your Moodle directory.
 
 ## In version
 
+### 2026040502:
+- Added uniqueness checks for issued certificate codes and a unique database index for new installations.
+
 ### 2026040501:
 - Update the certificate cleaning cron to the new task API.
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -74,6 +74,7 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="certificate_user" UNIQUE="false" FIELDS="certificateid, userid"/>
+        <INDEX NAME="code" UNIQUE="true" FIELDS="code"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -259,5 +259,30 @@ function xmldb_simplecertificate_upgrade($oldversion = 0) {
         set_config('certlifetime', 0, 'simplecertificate');
     }
 
+    if ($oldversion < 2026040502) {
+        // Define unique index code to be added to simplecertificate_issues.
+        $table = new xmldb_table('simplecertificate_issues');
+        $index = new xmldb_index('code', XMLDB_INDEX_UNIQUE, ['code']);
+
+        if (!$dbman->index_exists($table, $index)) {
+            $duplicates = $DB->get_records_sql(
+                "SELECT code, COUNT(id) AS duplicatecount
+                   FROM {simplecertificate_issues}
+                  GROUP BY code
+                 HAVING COUNT(id) > 1",
+                null,
+                0,
+                1
+            );
+
+            if (empty($duplicates)) {
+                $dbman->add_index($table, $index);
+            }
+        }
+
+        // Simplecertificate savepoint reached.
+        upgrade_mod_savepoint(true, 2026040502, 'simplecertificate');
+    }
+
     return true;
 }

--- a/lang/en/simplecertificate.php
+++ b/lang/en/simplecertificate.php
@@ -173,6 +173,7 @@ $string['enableidentity'] = 'Enable user identity';
 $string['enableidentity_help'] = 'Enable the use of the "username" field in certificates. By default the {USERNAME} tag prints the full name of the user so the {IDENTITY} tag is used for the "username". In the future the {USERNAME} tag will be removed to avoid confusion.';
 $string['enablesecondpage'] = 'Enable Certificate Back page';
 $string['enablesecondpage_help'] = 'Enable Certificate Back page edition, if is disabled, only certificate QR code will be printed in back page (if the QR code is enabled)';
+$string['errorgeneratingcertificatecode'] = 'A unique certificate code could not be generated. Please try again.';
 $string['eventcertificate_verified'] = 'Certificate verified';
 $string['eventcertificate_verified_description'] = 'The user with id {$a->userid} verified the certificate with id {$a->certificateid}, issued to user with id {$a->certiticate_userid}.';
 $string['filenotfound'] = 'File not Found';

--- a/locallib.php
+++ b/locallib.php
@@ -682,7 +682,7 @@ class simplecertificate {
             $formatedcertificatename = str_replace('-', '_', $this->get_instance()->name);
             $issuedcert->certificatename = format_string($formatedcoursename . '-' . $formatedcertificatename, true);
             $issuedcert->timecreated = time();
-            $issuedcert->code = $this->get_issue_uuid();
+            $issuedcert->code = $this->get_unique_issue_code();
             // Avoiding not null restriction.
             $issuedcert->pathnamehash = '';
 
@@ -928,6 +928,29 @@ class simplecertificate {
         global $CFG;
         require_once($CFG->libdir . '/classes/uuid.php');
         return \core\uuid::generate();
+    }
+
+    /**
+     * Generate an issued certificate code that is not already in use.
+     *
+     * Certificate codes are used for public verification and web service lookups,
+     * so new codes must not collide with any existing issued certificate record.
+     *
+     * @return string Unique certificate code
+     * @throws moodle_exception If a unique code cannot be generated
+     */
+    protected function get_unique_issue_code() {
+        global $DB;
+
+        for ($attempt = 0; $attempt < 10; $attempt++) {
+            $code = $this->get_issue_uuid();
+
+            if (!$DB->record_exists('simplecertificate_issues', ['code' => $code])) {
+                return $code;
+            }
+        }
+
+        throw new moodle_exception('errorgeneratingcertificatecode', 'simplecertificate');
     }
 
     /**

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -226,6 +226,9 @@ class testable_simplecertificate extends simplecertificate {
 
     const PLUGIN_VERSION = '2.2.2';
 
+    /** @var array $issueuuidqueue UUID values to return during tests */
+    private $issueuuidqueue = [];
+
     /**
      * Overwrites parents to format $formdata
      * @see simplecertificate::update_instance()
@@ -365,6 +368,28 @@ class testable_simplecertificate extends simplecertificate {
      */
     public function testable_get_date($certissue, $userid = null) {
         return parent::get_date($certissue, $userid);
+    }
+
+    /**
+     * Set deterministic UUID values for code generation tests.
+     *
+     * @param array $issueuuidqueue UUID values to return from get_issue_uuid()
+     */
+    public function testable_set_issue_uuid_queue(array $issueuuidqueue) {
+        $this->issueuuidqueue = $issueuuidqueue;
+    }
+
+    /**
+     * Generate a UUID from the deterministic test queue when available.
+     *
+     * @return string UUID
+     */
+    protected function get_issue_uuid() {
+        if (!empty($this->issueuuidqueue)) {
+            return array_shift($this->issueuuidqueue);
+        }
+
+        return parent::get_issue_uuid();
     }
 
     /**

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -202,6 +202,35 @@ class locallib_test extends mod_simplecertificate_base_testcase {
                                                ['code' => $issuecert->code]));
     }
 
+    public function test_create_issue_code_skips_existing_code() {
+        global $DB;
+
+        $cert = $this->create_instance();
+        $collisioncode = '00000000-0000-4000-8000-000000000001';
+        $uniquecode = '00000000-0000-4000-8000-000000000002';
+
+        $existingissue = (object)[
+            'certificateid' => $cert->get_instance()->id,
+            'userid' => $this->students[0]->id,
+            'certificatename' => 'Existing certificate',
+            'code' => $collisioncode,
+            'timecreated' => time(),
+            'timedeleted' => null,
+            'haschange' => 0,
+            'pathnamehash' => '',
+            'coursename' => $cert->get_instance()->coursename,
+        ];
+        $DB->insert_record('simplecertificate_issues', $existingissue);
+
+        $cert->testable_set_issue_uuid_queue([$collisioncode, $uniquecode]);
+        $issuecert = $cert->get_issue($this->students[1]);
+
+        $this->assertEquals($uniquecode, $issuecert->code);
+        $this->assertEquals(1, $DB->count_records('simplecertificate_issues', ['code' => $collisioncode]));
+        $this->assertEquals($this->students[1]->id,
+                            $DB->get_field('simplecertificate_issues', 'userid', ['code' => $uniquecode]));
+    }
+
     public function test_update_instace_update_haschange_issues() {
         global $DB;
 

--- a/version.php
+++ b/version.php
@@ -26,11 +26,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2026040501;
+$plugin->version  = 2026040502;
 $plugin->requires = 2025041403;
 $plugin->component = 'mod_simplecertificate';
 $plugin->dependencies = [];
-$plugin->release  = '5.1.2';
+$plugin->release  = '5.1.3';
 // MATURITY_ALPHA, MATURITY_BETA, MATURITY_RC, MATURITY_STABLE.
 $plugin->maturity = MATURITY_BETA;
 $plugin->supported = [501, 501];


### PR DESCRIPTION
## Summary
- add a uniqueness check when generating issued certificate codes
- add a unique `code` index for new installations
- add an upgrade step that creates the unique index when existing data has no duplicate codes
- add PHPUnit coverage for UUID collision handling
- bump plugin version/release and document the change

## Rationale
Certificate codes are used for public verification and web service lookup. If two issued certificates share the same code, verification can return the wrong record or become ambiguous. This change prevents new duplicate codes and lets clean installations enforce the constraint at the database level.

For existing sites that already contain duplicates, the upgrade step does not silently rewrite historical codes because those values may already be printed in generated PDFs or shared externally. The application-level uniqueness check still prevents additional duplicates going forward.

## Validation
- ran `git diff --check`
- parsed `db/install.xml` as XML
- reviewed the changed issue-generation path and upgrade logic manually
- PHPUnit was not run locally because PHP/Composer are not available on this Windows PATH

Addresses #254.