### PR TITLE
Handle unavailable remote images in certificate HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Place this folder in your mod folder in your Moodle directory.
 
 ## In version
 
+### 2026040504:
+- Improved certificate rendering resilience when configured HTML contains unavailable remote images.
+
 ### 2026040501:
 - Update the certificate cleaning cron to the new task API.
 

--- a/locallib.php
+++ b/locallib.php
@@ -1675,7 +1675,9 @@ class simplecertificate {
 
         // Clear not setted  textmark.
         $certtext = preg_replace('[\{(.*)\}]', "", $certtext);
-        return $this->remove_links(format_text($certtext, FORMAT_MOODLE));
+        $certtext = $this->remove_links(format_text($certtext, FORMAT_MOODLE));
+
+        return $this->prepare_certificate_html_for_pdf($certtext);
     }
 
     // Auto link filter puts links in the certificate text,
@@ -1706,6 +1708,172 @@ class simplecertificate {
         $config->set('HTML.ForbiddenElements', ['script', 'style', 'applet', 'a']);
         $purifier = new HTMLPurifier($config);
         return $purifier->purify($htmltext);
+    }
+
+    /**
+     * Prepares certificate HTML for TCPDF rendering.
+     *
+     * Broken remote images can stop TCPDF from rendering the remainder of the HTML cell. Keep local and data images
+     * untouched, but remove unavailable HTTP(S) images before the HTML is passed to TCPDF.
+     *
+     * @param string $htmltext Certificate HTML
+     * @return string Certificate HTML safe for TCPDF rendering
+     */
+    protected function prepare_certificate_html_for_pdf($htmltext) {
+        if (stripos($htmltext, '<img') === false) {
+            return $htmltext;
+        }
+
+        return preg_replace_callback('/<img\b(?=[^>]*\bsrc\s*=)[^>]*>/i', function($matches) {
+            $tag = $matches[0];
+            $src = $this->get_img_tag_attribute($tag, 'src');
+
+            if ($src === null || !$this->is_remote_certificate_image($src)) {
+                return $tag;
+            }
+
+            if ($this->remote_certificate_image_exists($src)) {
+                return $tag;
+            }
+
+            return $this->get_img_tag_fallback_text($tag);
+        }, $htmltext);
+    }
+
+    /**
+     * Gets an attribute value from an HTML img tag.
+     *
+     * @param string $tag HTML img tag
+     * @param string $attribute Attribute name
+     * @return string|null Attribute value, or null if missing
+     */
+    protected function get_img_tag_attribute($tag, $attribute) {
+        $pattern = '/\b' . preg_quote($attribute, '/') . '\s*=\s*(["\'])(.*?)\1/i';
+        if (preg_match($pattern, $tag, $matches)) {
+            return trim(html_entity_decode($matches[2], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        }
+
+        $pattern = '/\b' . preg_quote($attribute, '/') . '\s*=\s*([^\s>]+)/i';
+        if (preg_match($pattern, $tag, $matches)) {
+            return trim(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8'), "\"' \t\r\n");
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks whether an image URL points to a remote HTTP(S) resource.
+     *
+     * @param string $src Image source
+     * @return bool
+     */
+    protected function is_remote_certificate_image($src) {
+        return preg_match('/^https?:\/\//i', $src) === 1;
+    }
+
+    /**
+     * Checks whether a remote certificate image appears available.
+     *
+     * @param string $url Image URL
+     * @return bool
+     */
+    protected function remote_certificate_image_exists($url) {
+        if (!function_exists('curl_init')) {
+            return true;
+        }
+
+        $response = $this->get_remote_certificate_image_response($url, true);
+        if ($this->is_successful_remote_certificate_image_response($response)) {
+            return true;
+        }
+
+        if (!empty($response['httpcode']) && $response['httpcode'] < 400) {
+            return false;
+        }
+
+        $response = $this->get_remote_certificate_image_response($url, false);
+        return $this->is_successful_remote_certificate_image_response($response);
+    }
+
+    /**
+     * Performs a short remote image availability request.
+     *
+     * @param string $url Image URL
+     * @param bool $headonly Whether to use a HEAD request
+     * @return array Response metadata
+     */
+    protected function get_remote_certificate_image_response($url, $headonly) {
+        $curl = curl_init($url);
+        if (!$curl) {
+            return [
+                'httpcode' => 0,
+                'contenttype' => '',
+            ];
+        }
+
+        $options = [
+            CURLOPT_CONNECTTIMEOUT => 2,
+            CURLOPT_TIMEOUT => 5,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS => 3,
+            CURLOPT_NOBODY => $headonly,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_USERAGENT => 'Moodle SimpleCertificate',
+        ];
+
+        if (!$headonly) {
+            $options[CURLOPT_RANGE] = '0-0';
+        }
+
+        if (defined('CURLOPT_PROTOCOLS')) {
+            $options[CURLOPT_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+        }
+
+        if (defined('CURLOPT_REDIR_PROTOCOLS')) {
+            $options[CURLOPT_REDIR_PROTOCOLS] = CURLPROTO_HTTP | CURLPROTO_HTTPS;
+        }
+
+        curl_setopt_array($curl, $options);
+        curl_exec($curl);
+        $response = [
+            'httpcode' => (int)curl_getinfo($curl, CURLINFO_RESPONSE_CODE),
+            'contenttype' => (string)curl_getinfo($curl, CURLINFO_CONTENT_TYPE),
+        ];
+        curl_close($curl);
+
+        return $response;
+    }
+
+    /**
+     * Checks whether remote image response metadata is usable by TCPDF.
+     *
+     * @param array $response Response metadata
+     * @return bool
+     */
+    protected function is_successful_remote_certificate_image_response(array $response) {
+        if (empty($response['httpcode']) || $response['httpcode'] < 200 || $response['httpcode'] >= 400) {
+            return false;
+        }
+
+        if (empty($response['contenttype'])) {
+            return true;
+        }
+
+        return preg_match('/^image\//i', $response['contenttype']) === 1;
+    }
+
+    /**
+     * Gets replacement text for an unavailable image tag.
+     *
+     * @param string $tag HTML img tag
+     * @return string Escaped alt text or an empty string
+     */
+    protected function get_img_tag_fallback_text($tag) {
+        $alt = $this->get_img_tag_attribute($tag, 'alt');
+
+        return empty($alt) ? '' : s($alt);
     }
 
     protected function remove_user_image($userid) {

--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -226,6 +226,9 @@ class testable_simplecertificate extends simplecertificate {
 
     const PLUGIN_VERSION = '2.2.2';
 
+    /** @var array Remote image availability map for certificate HTML tests. */
+    private $remoteimageavailability = [];
+
     /**
      * Overwrites parents to format $formdata
      * @see simplecertificate::update_instance()
@@ -352,6 +355,22 @@ class testable_simplecertificate extends simplecertificate {
 
     public function testable_get_certificate_text($issuecert, $certtext = null) {
         return parent::get_certificate_text($issuecert, $certtext);
+    }
+
+    public function testable_set_remote_image_availability(array $availability) {
+        $this->remoteimageavailability = $availability;
+    }
+
+    public function testable_prepare_certificate_html_for_pdf($htmltext) {
+        return parent::prepare_certificate_html_for_pdf($htmltext);
+    }
+
+    protected function remote_certificate_image_exists($url) {
+        if (array_key_exists($url, $this->remoteimageavailability)) {
+            return $this->remoteimageavailability[$url];
+        }
+
+        return parent::remote_certificate_image_exists($url);
     }
 
     /**

--- a/tests/locallib_test.php
+++ b/tests/locallib_test.php
@@ -139,6 +139,46 @@ class locallib_test extends mod_simplecertificate_base_testcase {
         $this->assertStringNotContainsString("{", $secondpagetext, 'Second page text should not contain unprocessed placeholders');
     }
 
+    public function test_certificate_text_removes_unavailable_remote_images() {
+        $cert = $this->create_instance();
+        $cert->testable_set_remote_image_availability([
+            'https://example.test/missing.png' => false,
+        ]);
+
+        $html = 'Before <img src="https://example.test/missing.png" alt="Unavailable badge"> After';
+        $cleanhtml = $cert->testable_prepare_certificate_html_for_pdf($html);
+
+        $this->assertStringContainsString('Before', $cleanhtml);
+        $this->assertStringContainsString('Unavailable badge', $cleanhtml);
+        $this->assertStringContainsString('After', $cleanhtml);
+        $this->assertStringNotContainsString('<img', $cleanhtml);
+        $this->assertStringNotContainsString('missing.png', $cleanhtml);
+    }
+
+    public function test_certificate_text_keeps_available_remote_images() {
+        $cert = $this->create_instance();
+        $cert->testable_set_remote_image_availability([
+            'https://example.test/available.png' => true,
+        ]);
+
+        $html = 'Before <img src="https://example.test/available.png" alt="Available badge"> After';
+        $cleanhtml = $cert->testable_prepare_certificate_html_for_pdf($html);
+
+        $this->assertStringContainsString('<img', $cleanhtml);
+        $this->assertStringContainsString('available.png', $cleanhtml);
+        $this->assertStringContainsString('After', $cleanhtml);
+    }
+
+    public function test_certificate_text_keeps_local_images() {
+        $cert = $this->create_instance();
+
+        $html = 'Before <img src="@@PLUGINFILE@@/badge.png" alt="Local badge"> After';
+        $cleanhtml = $cert->testable_prepare_certificate_html_for_pdf($html);
+
+        $this->assertStringContainsString('<img', $cleanhtml);
+        $this->assertStringContainsString('@@PLUGINFILE@@/badge.png', $cleanhtml);
+    }
+
     public function test_create_issue_instance() {
         global $DB;
 

--- a/version.php
+++ b/version.php
@@ -26,11 +26,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2026040501;
+$plugin->version  = 2026040504;
 $plugin->requires = 2025041403;
 $plugin->component = 'mod_simplecertificate';
 $plugin->dependencies = [];
-$plugin->release  = '5.1.2';
+$plugin->release  = '5.1.5';
 // MATURITY_ALPHA, MATURITY_BETA, MATURITY_RC, MATURITY_STABLE.
 $plugin->maturity = MATURITY_BETA;
 $plugin->supported = [501, 501];


### PR DESCRIPTION
## Summary

Improves certificate PDF rendering resilience when certificate HTML contains remote image links that later become unavailable.

This addresses #246, where a broken external image could cause TCPDF to stop rendering the rest of the certificate text after the failed image.

## Changes

- Added a pre-render HTML guard for certificate text before it is passed to TCPDF.
- Preserved local Moodle file references and available remote images.
- Removed unavailable HTTP(S) image tags so following text can still render.
- Used image alt text as the fallback content when available.
- Added focused test coverage for unavailable remote images, available remote images, and local plugin file image references.
- Bumped the plugin version for the rendering behavior change.

## Validation

- `git diff --check` passes.
- PHPUnit was not run locally because PHP/Composer/Docker are not available in this Windows workspace.